### PR TITLE
Configure build workflows for releases with extended timeout

### DIFF
--- a/.github/workflows/pro-app-build.yml
+++ b/.github/workflows/pro-app-build.yml
@@ -1,5 +1,10 @@
 name: "pro app build"
 on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -75,7 +80,7 @@ jobs:
 
       - name: Build and Push for ${{ matrix.platform }}
         uses: docker/build-push-action@v6
-        timeout-minutes: 60
+        timeout-minutes: 120
         with:
           context: ./meme_search/meme_search_app
           platforms: ${{ matrix.platform }}

--- a/.github/workflows/pro-image-to-text-build.yml
+++ b/.github/workflows/pro-image-to-text-build.yml
@@ -1,5 +1,10 @@
 name: "pro image to text build"
 on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -88,7 +93,7 @@ jobs:
 
       - name: Build and Upload for AMD64 and ARM64
         uses: docker/build-push-action@v6
-        timeout-minutes: 60
+        timeout-minutes: 120
         with:
           context: ./meme_search/image_to_text_generator
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
- Add automatic triggers for tags (v*) and releases
- Increase build timeout from 60 to 120 minutes for ARM64 builds
- Keep workflow_dispatch for manual builds
- ARM64 builds under QEMU emulation need extra time to complete

This addresses ARM64 timeout issues while maintaining flexibility for both automated release builds and manual testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)