### PR TITLE
Fix VERSION file visibility in Docker builds

### DIFF
--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -1,8 +1,8 @@
 services:
   meme_search:
     build:
-      context: ./meme_search/meme_search_app
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ./meme_search/meme_search_app/Dockerfile
     container_name: meme_search
     environment:
       DATABASE_URL: "postgres://postgres:postgres@meme-search-db:${DB_PORT:-5432}/meme_search"

--- a/meme_search/meme_search_app/Dockerfile
+++ b/meme_search/meme_search_app/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems with BuildKit cache mounts
-COPY Gemfile Gemfile.lock ./
+COPY meme_search/meme_search_app/Gemfile meme_search/meme_search_app/Gemfile.lock ./
 RUN --mount=type=cache,target=/usr/local/bundle/cache \
     --mount=type=cache,target=/root/.bundle \
     bundle config set --local jobs 4 && \
@@ -40,8 +40,11 @@ RUN --mount=type=cache,target=/usr/local/bundle/cache \
     rm -rf "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile
 
+# Copy VERSION file from repository root
+COPY VERSION ./
+
 # Copy application code
-COPY . .
+COPY meme_search/meme_search_app/ .
 
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/

--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -141,6 +141,7 @@ build_service() {
   local service_name=$1
   local context_path=$2
   local image_name=$3
+  local dockerfile_flag=$4
 
   echo -e "${BLUE}Building ${service_name} (${PLATFORM_NAME})...${NC}"
 
@@ -149,6 +150,7 @@ build_service() {
   docker buildx build --platform "$PLATFORM" \
     -t "ghcr.io/${GITHUB_USER}/${image_name}:latest" \
     $PUSH_FLAG \
+    $dockerfile_flag \
     "$context_path"
 
   END_TIME=$(date +%s)
@@ -160,7 +162,7 @@ build_service() {
 
 # Build services
 if [ "$SERVICE" = "app" ] || [ "$SERVICE" = "all" ]; then
-  build_service "Rails App" "./meme_search/meme_search_app" "meme_search"
+  build_service "Rails App" "." "meme_search" "-f ./meme_search/meme_search_app/Dockerfile"
 fi
 
 if [ "$SERVICE" = "python" ] || [ "$SERVICE" = "all" ]; then


### PR DESCRIPTION
Problem: VERSION file (2.0.1) was not being copied into Docker images, causing containerized deployments to display "unknown" instead of the actual version number in footer and about page.

Changes:
- Update Dockerfile to use repository root as build context
- Add explicit COPY of VERSION file from repository root
- Update all COPY paths to be relative to repository root
- Modify docker-compose-local-build.yml to use root context
- Update build_and_push.sh script to handle new dockerfile location

Files modified:
- meme_search/meme_search_app/Dockerfile: Updated COPY commands for VERSION
- docker-compose-local-build.yml: Changed build context to repository root
- scripts/build_and_push.sh: Added dockerfile flag parameter support

Testing:
- All Rails tests passing (7/7 pages controller tests)
- VERSION loading verified via "about_page_displays_app_version" test
- Ready for Docker build validation

Result: Containerized deployments will now correctly display "v2.0.1" in footer and about page instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)