### PR TITLE
Fix VERSION file path resolution for Docker containers

### DIFF
--- a/meme_search/meme_search_app/config/initializers/version.rb
+++ b/meme_search/meme_search_app/config/initializers/version.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
-# Load application version from VERSION file at repository root
-VERSION_FILE = Rails.root.join("..", "..", "VERSION")
+# Load application version from VERSION file
+# In development: two levels up from Rails.root (repository root)
+# In Docker: Rails.root (copied during build)
+VERSION_FILE = if File.exist?(Rails.root.join("VERSION"))
+  Rails.root.join("VERSION")
+else
+  Rails.root.join("..", "..", "VERSION")
+end
+
 APP_VERSION = if File.exist?(VERSION_FILE)
   File.read(VERSION_FILE).strip
 else


### PR DESCRIPTION
Problem: VERSION initializer was looking for file at Rails.root/../.., but in Docker builds the VERSION file is copied to Rails.root, causing it to display "unknown" in production containers.

Solution: Update initializer to check Rails.root first (Docker), then fall back to repository root path (development/local).

Changes:
- Check if VERSION exists at Rails.root/VERSION first
- Fall back to Rails.root/../../VERSION for development
- Maintains compatibility with both Docker and local development

Testing:
- Development: APP_VERSION = "2.0.1" ✓
- Docker: APP_VERSION = "2.0.1" ✓
- All pages controller tests passing (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)