### PR TITLE
Update Discord link and add link validation to CI

### DIFF
--- a/.github/workflows/pro-app-test.yml
+++ b/.github/workflows/pro-app-test.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "meme_search/meme_search_app/**"
       - ".github/workflows/pro-app-test.yml"
+      - "README.md"
+      - "scripts/validate_discord_link.sh"
       - "!meme_search/meme_search_app/**/*.md"
       - "!meme_search/meme_search_app/**/LICENSE"
   push:
@@ -14,10 +16,22 @@ on:
     paths:
       - "meme_search/meme_search_app/**"
       - ".github/workflows/pro-app-test.yml"
+      - "README.md"
+      - "scripts/validate_discord_link.sh"
       - "!meme_search/meme_search_app/**/*.md"
       - "!meme_search/meme_search_app/**/LICENSE"
 
 jobs:
+  validate_discord_link:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Discord link in README.md
+        run: bash scripts/validate_discord_link.sh
+
   pro_app_ruby_check:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# A Meme Search Engine built to self-host in Python, Ruby, and Docker 
+# A Meme Search Engine built to self-host in Python, Ruby, and Docker
 
-[![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.com/invite/8EUxqR93)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/damGu7aEHH)
 
 Use AI to index your memes by their content and text, making them easily retrievable for your meme warfare pleasures.
 
@@ -326,7 +326,7 @@ See `playwright-docker/README.md` for comprehensive documentation.
 
 ## Discord server
 
-Join our Discord server [![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.com/invite/8EUxqR93) to discuss new features, bug fixes, and other open source projects (like [ytgify](https://chromewebstore.google.com/detail/ytgify/dnljofakogbecppbkmnoffppkfdmpfje) - a browser extension for clipping GIFs from YouTube right from the YT Player!).
+Join our Discord server [![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/damGu7aEHH) to discuss new features, bug fixes, and other open source projects (like [ytgify](https://chromewebstore.google.com/detail/ytgify/dnljofakogbecppbkmnoffppkfdmpfje) - a browser extension for clipping GIFs from YouTube right from the YT Player!).
 
 ## Changelog
 

--- a/meme_search/meme_search_app/app/views/pages/about.html.erb
+++ b/meme_search/meme_search_app/app/views/pages/about.html.erb
@@ -20,30 +20,27 @@
              class="text-fuchsia-600 dark:text-fuchsia-400 hover:text-fuchsia-700 dark:hover:text-fuchsia-300 font-semibold transition-colors">
             Submit an issue on GitHub
           </a>
-          or join our
-          <a href="https://discord.gg/8EUxqR93"
-             target="_blank"
-             rel="noopener noreferrer"
-             class="text-fuchsia-600 dark:text-fuchsia-400 hover:text-fuchsia-700 dark:hover:text-fuchsia-300 font-semibold transition-colors">
-            Discord community
-          </a>
-          to discuss!
+          or join our Discord community to discuss!
         </p>
       </section>
 
       <section class="pt-6 border-t border-gray-200 dark:border-gray-700">
         <div class="text-center">
-          <a href="https://discord.gg/8EUxqR93"
-             target="_blank"
-             rel="noopener noreferrer"
-             class="inline-flex items-center gap-2 px-6 py-3 bg-white dark:bg-slate-700 text-slate-800 dark:text-white font-semibold rounded-lg border-2 border-slate-900 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600 hover:border-slate-700 dark:hover:border-slate-500 transition-all transform hover:scale-105">
+          <div class="inline-flex items-center gap-2 px-6 py-3 bg-white dark:bg-slate-700 text-slate-800 dark:text-white font-semibold rounded-lg border-2 border-slate-900 dark:border-slate-600">
             <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z"/>
             </svg>
-            Join our Discord community
-          </a>
+            Discord Community
+          </div>
           <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
-            Discuss new feature ideas and troubleshooting tips
+            For the latest Discord invite link, visit the
+            <a href="https://github.com/neonwatty/meme-search#discord-server"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="text-fuchsia-600 dark:text-fuchsia-400 hover:text-fuchsia-700 dark:hover:text-fuchsia-300 font-semibold transition-colors">
+              README.md
+            </a>
+            in the repo.
           </p>
         </div>
       </section>

--- a/playwright/tests/about.spec.ts
+++ b/playwright/tests/about.spec.ts
@@ -34,28 +34,28 @@ test.describe('About Page', () => {
     await expect(issuesLink).toBeVisible();
     await expect(issuesLink).toHaveText(/Submit an issue on GitHub/);
 
-    // Check for Discord link in Feedback section
-    const feedbackDiscordLink = page.locator('section:has-text("Feedback") a[href="https://discord.gg/8EUxqR93"]');
-    await expect(feedbackDiscordLink).toBeVisible();
-    await expect(feedbackDiscordLink).toHaveText(/Discord community/);
+    // Check for README link for Discord (replaces direct Discord link)
+    const readmeDiscordLink = page.locator('a[href="https://github.com/neonwatty/meme-search#discord-server"]');
+    await expect(readmeDiscordLink).toBeVisible();
+    await expect(readmeDiscordLink).toHaveText(/README\.md/);
   });
 
-  test('displays Discord community button', async ({ page }) => {
-    // Check for Discord community button (the large button, not the text link in Feedback)
-    const discordButton = page.locator('a[href="https://discord.gg/8EUxqR93"].inline-flex.px-6.py-3');
-    await expect(discordButton).toBeVisible();
-    await expect(discordButton).toHaveText(/Join our Discord community/);
+  test('displays Discord community section', async ({ page }) => {
+    // Check for Discord community div (no longer a link)
+    const discordSection = page.locator('div.inline-flex:has-text("Discord Community")');
+    await expect(discordSection).toBeVisible();
+    await expect(discordSection).toHaveText(/Discord Community/);
   });
 
-  test('Discord community button has correct styling', async ({ page }) => {
-    // Locate the Discord button (the large button, not the text link)
-    const discordButton = page.locator('a[href="https://discord.gg/8EUxqR93"].inline-flex.px-6.py-3');
+  test('Discord community section has correct styling', async ({ page }) => {
+    // Locate the Discord section (now a div, not a link)
+    const discordSection = page.locator('div.inline-flex.px-6.py-3');
 
-    // Check that button is visible
-    await expect(discordButton).toBeVisible();
+    // Check that section is visible
+    await expect(discordSection).toBeVisible();
 
-    // Check that button has white/slate background (check classes)
-    const classes = await discordButton.getAttribute('class');
+    // Check that section has white/slate background (check classes)
+    const classes = await discordSection.getAttribute('class');
     expect(classes).toContain('bg-white');
     expect(classes).toContain('dark:bg-slate-700');
 
@@ -66,24 +66,21 @@ test.describe('About Page', () => {
     expect(classes).toContain('rounded-lg');
   });
 
-  test('Discord community button has correct attributes', async ({ page }) => {
-    // Target the large Discord button specifically
-    const discordButton = page.locator('a[href="https://discord.gg/8EUxqR93"].inline-flex.px-6.py-3');
+  test('README link has correct attributes', async ({ page }) => {
+    // Target the README link for Discord
+    const readmeLink = page.locator('a[href="https://github.com/neonwatty/meme-search#discord-server"]');
 
     // Check target="_blank" for opening in new tab
-    await expect(discordButton).toHaveAttribute('target', '_blank');
+    await expect(readmeLink).toHaveAttribute('target', '_blank');
 
     // Check rel="noopener noreferrer" for security
-    await expect(discordButton).toHaveAttribute('rel', 'noopener noreferrer');
-
-    // Check href points to correct URL
-    await expect(discordButton).toHaveAttribute('href', 'https://discord.gg/8EUxqR93');
+    await expect(readmeLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  test('Discord button includes Discord logo icon', async ({ page }) => {
-    // Check for SVG icon inside the Discord button (the large button)
-    const discordButton = page.locator('a[href="https://discord.gg/8EUxqR93"].inline-flex.px-6.py-3');
-    const icon = discordButton.locator('svg');
+  test('Discord section includes Discord logo icon', async ({ page }) => {
+    // Check for SVG icon inside the Discord section
+    const discordSection = page.locator('div.inline-flex.px-6.py-3');
+    const icon = discordSection.locator('svg');
 
     await expect(icon).toBeVisible();
 
@@ -92,27 +89,9 @@ test.describe('About Page', () => {
     await expect(iconPath).toBeVisible();
   });
 
-  test('displays Discord subtext', async ({ page }) => {
-    // Check for the descriptive text below the button
-    const subtext = page.locator('text=Discuss new feature ideas and troubleshooting tips');
+  test('displays Discord subtext with README link', async ({ page }) => {
+    // Check for the descriptive text below the Discord section
+    const subtext = page.locator('text=For the latest Discord invite link');
     await expect(subtext).toBeVisible();
-  });
-
-  test('Discord button hover state works', async ({ page }) => {
-    // Target the large Discord button specifically
-    const discordButton = page.locator('a[href="https://discord.gg/8EUxqR93"].inline-flex.px-6.py-3');
-
-    // Get initial bounding box
-    const initialBox = await discordButton.boundingBox();
-    expect(initialBox).not.toBeNull();
-
-    // Hover over button
-    await discordButton.hover();
-
-    // Wait a moment for transition
-    await page.waitForTimeout(200);
-
-    // Button should still be visible after hover
-    await expect(discordButton).toBeVisible();
   });
 });

--- a/scripts/validate_discord_link.sh
+++ b/scripts/validate_discord_link.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Script to validate the Discord invite link in README.md returns a valid HTTP response
+# This helps catch broken Discord links in CI before they reach users
+
+set -e
+
+# Extract Discord link from README.md (works on both macOS and Linux)
+DISCORD_URL=$(grep -oE 'https://discord\.gg/[a-zA-Z0-9]+' README.md | head -1)
+
+if [ -z "$DISCORD_URL" ]; then
+    echo "ERROR: No Discord link found in README.md"
+    exit 1
+fi
+
+echo "Found Discord link: $DISCORD_URL"
+
+# Make HTTP request and check status code
+# Discord invite links return 200 for valid invites, or redirect to Discord
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L "$DISCORD_URL")
+
+echo "HTTP Status: $HTTP_STATUS"
+
+# Accept 200, 301, 302 as valid (redirects are expected for Discord)
+if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+    echo "SUCCESS: Discord link is valid (HTTP $HTTP_STATUS)"
+    exit 0
+else
+    echo "ERROR: Discord link returned HTTP $HTTP_STATUS"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Update Discord invite link in README.md to the new URL (`discord.gg/damGu7aEHH`)
- Remove direct Discord links from app's About page to prevent future broken links
- Add note in the app directing users to the README.md for the latest Discord invite link
- Add Discord link validation script (`scripts/validate_discord_link.sh`) that runs in CI to catch broken links early
- Update Playwright tests to reflect the About page changes

## Test plan
- [x] Linting passes (RuboCop)
- [x] Pages controller tests pass (7/7)
- [x] Playwright about page tests pass (7/7)
- [x] Discord link validation script works locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)