### PR TITLE
Update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Meme Search Engine built to self-host in Python, Ruby, and Docker
 
-[![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/damGu7aEHH)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/7xsxU4ZG6A)
 
 Use AI to index your memes by their content and text, making them easily retrievable for your meme warfare pleasures.
 
@@ -335,7 +335,7 @@ See `playwright-docker/README.md` for comprehensive documentation.
 
 ## Discord server
 
-Join our Discord server [![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/damGu7aEHH) to discuss new features, bug fixes, and other open source projects (like [ytgify](https://chromewebstore.google.com/detail/ytgify/dnljofakogbecppbkmnoffppkfdmpfje) - a browser extension for clipping GIFs from YouTube right from the YT Player!).
+Join our Discord server [![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/7xsxU4ZG6A) to discuss new features, bug fixes, and other open source projects (like [ytgify](https://chromewebstore.google.com/detail/ytgify/dnljofakogbecppbkmnoffppkfdmpfje) - a browser extension for clipping GIFs from YouTube right from the YT Player!).
 
 ## Changelog
 


### PR DESCRIPTION
## Summary
- Update Discord badge to use permanent server-level invite (points to #general instead of #meme-search channel)
- Old invite: discord.gg/damGu7aEHH (channel-specific)
- New invite: discord.gg/7xsxU4ZG6A (server-level, never expires)