### PR TITLE
fix: make image description generation attempts durable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ meme_search/db_data
 **/__pycache__
 **.ruff_cache
 **models
+!meme_search/meme_search_app/app/models/
+!meme_search/meme_search_app/app/models/image_description_generation_attempt.rb
+!meme_search/meme_search_app/test/models/
+!meme_search/meme_search_app/test/models/image_description_generation_attempt_test.rb
 
 # Temporary planning/documentation files
 plans/temp*

--- a/meme_search/image_to_text_generator/app/app.py
+++ b/meme_search/image_to_text_generator/app/app.py
@@ -1,11 +1,13 @@
 import sqlite3
 import threading
-from fastapi import FastAPI
+import requests
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import ValidationError
 from data_models import JobModel
 from constants import APP_URL
 from constants import JOB_DB
 from job_queue import init_db
-from senders import status_sender
+import jobs as jobs_module
 from jobs import process_jobs
 from log_config import logging
 
@@ -17,6 +19,98 @@ logging.info(f"the local job db for the image to text service is defined as: {JO
 # initialize FastAPI app
 app = FastAPI()
 
+
+def ensure_attempt_columns(conn):
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA table_info(jobs)")
+    column_names = {row[1] for row in cursor.fetchall()}
+    if "attempt_id" not in column_names:
+        cursor.execute("ALTER TABLE jobs ADD COLUMN attempt_id INTEGER")
+    if "callback_token" not in column_names:
+        cursor.execute("ALTER TABLE jobs ADD COLUMN callback_token TEXT")
+    conn.commit()
+
+
+def attempt_details_for_image(image_core_id):
+    conn = sqlite3.connect(JOB_DB)
+    try:
+        ensure_attempt_columns(conn)
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT attempt_id, callback_token FROM jobs WHERE image_core_id = ? ORDER BY id LIMIT 1",
+            (image_core_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None, None
+        return row[0], row[1]
+    finally:
+        conn.close()
+
+
+def add_attempt_fields(payload, attempt_id=None, callback_token=None):
+    enriched = dict(payload)
+    if attempt_id is None or callback_token is None:
+        attempt_id, callback_token = attempt_details_for_image(payload["image_core_id"])
+    if attempt_id is not None and callback_token:
+        enriched["attempt_id"] = attempt_id
+        enriched["callback_token"] = callback_token
+    return enriched
+
+
+def post_callback(path, payload, app_url):
+    response = requests.post(app_url + path, json={"data": payload}, timeout=30)
+    return response.status_code >= 200 and response.status_code < 300, response.status_code
+
+
+def status_sender(status_job_details: dict, app_url: str) -> None:
+    try:
+        payload = add_attempt_fields(status_job_details)
+        success, status_code = post_callback("status_receiver", payload, app_url)
+        if success:
+            logging.info("SUCCESS: status_sender successfully delivered")
+        else:
+            logging.info("FAILURE: status_sender failed to deliver with response code %s", status_code)
+    except Exception as e:
+        logging.error(f"FAILURE: status_sender failed with exception {e}")
+
+
+def description_sender(output_job_details: dict, app_url: str) -> None:
+    try:
+        payload = add_attempt_fields(output_job_details)
+        success, status_code = post_callback("description_receiver", payload, app_url)
+        if success:
+            logging.info("SUCCESS: description_sender successfully delivered")
+        else:
+            logging.info("FAILURE: description_sender failed to deliver with response code %s", status_code)
+    except Exception as e:
+        logging.error(f"FAILURE: description_sender failed with exception {e}")
+
+
+def failure_sender(image_core_id: int, error_message: str, app_url: str) -> None:
+    attempt_id, callback_token = attempt_details_for_image(image_core_id)
+    status_sender(
+        add_attempt_fields(
+            {"image_core_id": image_core_id, "status": 5, "error_message": error_message},
+            attempt_id,
+            callback_token,
+        ),
+        app_url,
+    )
+    description_sender(
+        add_attempt_fields(
+            {"image_core_id": image_core_id, "description": f"Error: {error_message}"},
+            attempt_id,
+            callback_token,
+        ),
+        app_url,
+    )
+
+
+jobs_module.status_sender = status_sender
+jobs_module.description_sender = description_sender
+jobs_module.failure_sender = failure_sender
+
 @app.get("/")
 def home():
     logging.info("HELLO WORLD")
@@ -24,13 +118,23 @@ def home():
 
 
 @app.post("/add_job")
-def add_job(job: JobModel):
+async def add_job(request: Request):
+    raw_job = await request.json()
+    try:
+        job = JobModel(**raw_job)
+    except ValidationError as error:
+        raise HTTPException(status_code=422, detail=error.errors(include_context=False)) from error
+
+    attempt_id = job.attempt_id
+    callback_token = job.callback_token
+
     conn = sqlite3.connect(JOB_DB)
+    ensure_attempt_columns(conn)
     cursor = conn.cursor()
 
     cursor.execute(
-        "INSERT INTO jobs (image_core_id, image_path, model) VALUES (?, ?, ?)",
-        (job.image_core_id, job.image_path, job.model),
+        "INSERT INTO jobs (image_core_id, image_path, model, attempt_id, callback_token) VALUES (?, ?, ?, ?, ?)",
+        (job.image_core_id, job.image_path, job.model, attempt_id, callback_token),
     )
     conn.commit()
     conn.close()
@@ -38,7 +142,11 @@ def add_job(job: JobModel):
     logging.info("Job added to queue: %s", job)
 
     # update status
-    status_job_details = {"image_core_id": job.image_core_id, "status": 1}
+    status_job_details = add_attempt_fields(
+        {"image_core_id": job.image_core_id, "status": 1},
+        attempt_id,
+        callback_token,
+    )
 
     # send status update (image out of queue and in process)
     status_sender(status_job_details, APP_URL)
@@ -64,25 +172,21 @@ def check_queue():
 @app.delete("/remove_job/{image_core_id}")
 def remove_job(image_core_id: int):
     conn = sqlite3.connect(JOB_DB)
+    ensure_attempt_columns(conn)
     cursor = conn.cursor()
 
     # Check if the job exists
-    cursor.execute("SELECT * FROM jobs WHERE image_core_id = ?", (image_core_id,))
+    cursor.execute("SELECT attempt_id, callback_token FROM jobs WHERE image_core_id = ?", (image_core_id,))
     job = cursor.fetchone()
 
     if job is None:
         conn.close()
         logging.warning("Attempted to remove a job that does not exist: %s", image_core_id)
 
-        # send signal to update status
-        status_job_details = {"image_core_id": image_core_id, "status": 3}
-
-        # send status update (reset status)
-        status_sender(status_job_details, APP_URL)
-
         return {"status": "Job removed from queue"}
 
     # Remove the job from the database
+    attempt_id, callback_token = job
     cursor.execute("DELETE FROM jobs WHERE image_core_id = ?", (image_core_id,))
     conn.commit()
     conn.close()
@@ -90,7 +194,11 @@ def remove_job(image_core_id: int):
     logging.info("Job removed from queue: %s", image_core_id)
 
     # run status update
-    status_job_details = {"image_core_id": image_core_id, "status": 0}
+    status_job_details = add_attempt_fields(
+        {"image_core_id": image_core_id, "status": 0},
+        attempt_id,
+        callback_token,
+    )
     status_sender(status_job_details, APP_URL)
 
     return {"status": "Job removed from queue"}
@@ -122,6 +230,9 @@ if __name__ == "__main__":
 
     # Initialize the database
     init_db(JOB_DB)
+    conn = sqlite3.connect(JOB_DB)
+    ensure_attempt_columns(conn)
+    conn.close()
 
     # initialize model (optional)
     # init_model()

--- a/meme_search/image_to_text_generator/app/data_models.py
+++ b/meme_search/image_to_text_generator/app/data_models.py
@@ -6,6 +6,8 @@ from constants import available_models, default_model
 class JobModel(BaseModel):
     image_core_id: int
     image_path: str
+    attempt_id: int
+    callback_token: str
     model: str = default_model
 
     @field_validator("model")

--- a/meme_search/image_to_text_generator/tests/test_app.py
+++ b/meme_search/image_to_text_generator/tests/test_app.py
@@ -2,6 +2,7 @@ import subprocess
 import time
 import requests
 import os
+import sqlite3
 
 
 APP_START_CMD = ["python", "app/app.py", "testing"]  # Command for app start
@@ -91,7 +92,16 @@ def test_process_image():
         assert wait_for_server(DUMMY_URL), "Dummy server did not start in time"
 
         # Send in POST request with image_core_id, path to image, and 'test' model
-        response = requests.post(SERVER_URL + "/add_job", json={"image_core_id": 0, "image_path": "./app/do_not_remove.jpg", "model": "test"})
+        response = requests.post(
+            SERVER_URL + "/add_job",
+            json={
+                "image_core_id": 0,
+                "image_path": "./app/do_not_remove.jpg",
+                "model": "test",
+                "attempt_id": 101,
+                "callback_token": "signed-token-101",
+            },
+        )
 
         # Verify response
         assert response.status_code == 200
@@ -103,7 +113,16 @@ def test_process_image():
         assert response.json() == {"queue_length": 1}, "Queue length is not 1"
 
         # Send in second POST request with image_core_id, path to image, and 'test' model
-        response = requests.post(SERVER_URL + "/add_job", json={"image_core_id": 1, "image_path": "./app/do_not_remove.jpg", "model": "test"})
+        response = requests.post(
+            SERVER_URL + "/add_job",
+            json={
+                "image_core_id": 1,
+                "image_path": "./app/do_not_remove.jpg",
+                "model": "test",
+                "attempt_id": 102,
+                "callback_token": "signed-token-102",
+            },
+        )
         assert response.status_code == 200
         assert response.json() == {"status": "Job added to queue"}
 
@@ -140,6 +159,57 @@ def test_process_image():
         dummy_process.wait()
 
 
+def test_add_and_remove_job_preserves_attempt_callback_fields():
+    """Test that optional attempt metadata is stored and sent on queue callbacks."""
+    app_process = subprocess.Popen(APP_START_CMD, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    dummy_process = subprocess.Popen(DUMMY_START_CMD, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    os.set_blocking(app_process.stderr.fileno(), False)
+    os.set_blocking(dummy_process.stderr.fileno(), False)
+
+    try:
+        assert wait_for_server(SERVER_URL, timeout=30), "Image to text server did not start in time"
+        assert wait_for_server(DUMMY_URL), "Dummy server did not start in time"
+
+        response = requests.post(
+            SERVER_URL + "/add_job",
+            json={
+                "image_core_id": 77,
+                "image_path": "./app/do_not_remove.jpg",
+                "model": "test",
+                "attempt_id": 177,
+                "callback_token": "signed-token-177",
+            },
+        )
+        assert response.status_code == 200
+
+        conn = sqlite3.connect("tests/db/job_queue.db")
+        cursor = conn.cursor()
+        cursor.execute("SELECT attempt_id, callback_token FROM jobs WHERE image_core_id = ?", (77,))
+        row = cursor.fetchone()
+        conn.close()
+        assert row == (177, "signed-token-177")
+
+        response = requests.delete(SERVER_URL + "/remove_job/77")
+        assert response.status_code == 200
+
+        time.sleep(1)
+        dummy_logs = ""
+        for _ in range(30):
+            line = dummy_process.stderr.readline()
+            if line:
+                dummy_logs += line
+
+        assert "'attempt_id': 177" in dummy_logs or '"attempt_id": 177' in dummy_logs
+        assert "signed-token-177" in dummy_logs
+
+    finally:
+        app_process.terminate()
+        app_process.wait()
+        dummy_process.terminate()
+        dummy_process.wait()
+
+
 # REMOVED: test_processing_florence_base() - too slow for CI (60s+, downloads 500MB AI model)
 # Real AI model testing is covered by unit tests (tests/unit/test_image_to_text_generator.py)
 # The 'test' model above provides sufficient integration test coverage
@@ -167,7 +237,13 @@ def test_missing_image_sends_failure_and_removes_job():
         # Submit job with a path to a file that doesn't exist
         response = requests.post(
             SERVER_URL + "/add_job",
-            json={"image_core_id": 999, "image_path": "./nonexistent/missing_image.jpg", "model": "test"}
+            json={
+                "image_core_id": 999,
+                "image_path": "./nonexistent/missing_image.jpg",
+                "model": "test",
+                "attempt_id": 1999,
+                "callback_token": "signed-token-1999",
+            }
         )
         assert response.status_code == 200
         assert response.json() == {"status": "Job added to queue"}
@@ -245,7 +321,13 @@ def test_corrupt_image_sends_failure_and_removes_job():
         # Submit job with corrupt image
         response = requests.post(
             SERVER_URL + "/add_job",
-            json={"image_core_id": 888, "image_path": corrupt_file.name, "model": "test"}
+            json={
+                "image_core_id": 888,
+                "image_path": corrupt_file.name,
+                "model": "test",
+                "attempt_id": 1888,
+                "callback_token": "signed-token-1888",
+            }
         )
         assert response.status_code == 200
 
@@ -275,68 +357,3 @@ def test_corrupt_image_sends_failure_and_removes_job():
         dummy_process.wait()
         # Clean up temp file
         os.unlink(corrupt_file.name)
-
-
-# def test_processing_smolvlm_256():
-#     """Test processing with 'SmolVLM-256M-Instruct' model."""
-#     app_process = subprocess.Popen(APP_START_CMD, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-#     dummy_process = subprocess.Popen(DUMMY_START_CMD, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-
-#     os.set_blocking(app_process.stdout.fileno(), False)
-#     os.set_blocking(dummy_process.stdout.fileno(), False)
-
-#     try:
-#         # Start image to text serverserver
-#         assert wait_for_server(SERVER_URL), "Image to text server did not start in time"
-
-#         # Start dummy server to receive sender messages
-#         assert wait_for_server(DUMMY_URL), "Dummy server did not start in time"
-
-#         # Send in POST request with image_core_id, path to image, and 'test' model
-#         response = requests.post(SERVER_URL + "/add_job", json={"image_core_id": 0, "image_path": "./app/do_not_remove.jpg", "model": "SmolVLM-256M-Instruct"})
-
-#         # Verify response
-#         assert response.status_code == 200
-#         assert response.json() == {"status": "Job added to queue"}
-
-#         # Check queue
-#         response = requests.get(SERVER_URL + "/check_queue")
-#         assert response.status_code == 200
-#         assert response.json() == {"queue_length": 1}, "Queue length is not 1"
-
-#         # Send in second POST request with image_core_id, path to image, and 'test' model
-#         response = requests.post(SERVER_URL + "/add_job", json={"image_core_id": 1, "image_path": "./app/do_not_remove.jpg", "model": "SmolVLM-256M-Instruct"})
-#         assert response.status_code == 200
-#         assert response.json() == {"status": "Job added to queue"}
-
-#         # Check queue
-#         response = requests.get(SERVER_URL + "/check_queue")
-#         assert response.status_code == 200
-#         assert response.json() == {"queue_length": 2}, "Queue length is not 2"
-
-#         # Remove job
-#         response = requests.delete(SERVER_URL + "/remove_job/1")
-#         assert response.status_code == 200
-#         assert response.json() == {"status": "Job removed from queue"}
-
-#         # Check queue
-#         response = requests.get(SERVER_URL + "/check_queue")
-#         assert response.status_code == 200
-#         assert response.json() == {"queue_length": 1}, "Queue length is not 1"
-
-#         # Tail dummy server logs
-#         time.sleep(60)
-#         app_logs = ""
-#         for _ in range(40):
-#             logline = app_process.stderr.readline().strip()
-#             if isinstance(logline, str):
-#                 app_logs += logline
-#         print(app_logs)
-#         assert "status_sender successfully delivered" in app_logs, "status_sender failed"
-#         assert "description_sender successfully delivered" in app_logs, "description_sender failed"
-
-#     finally:
-#         app_process.terminate()  
-#         app_process.wait() 
-#         dummy_process.terminate()
-#         dummy_process.wait()

--- a/meme_search/image_to_text_generator/tests/unit/test_api.py
+++ b/meme_search/image_to_text_generator/tests/unit/test_api.py
@@ -41,6 +41,16 @@ def client(test_db, monkeypatch):
     return TestClient(app)
 
 
+def job_payload(image_core_id: int, image_path: str = "/path/to/image.jpg", model: str = "test"):
+    return {
+        "image_core_id": image_core_id,
+        "image_path": image_path,
+        "model": model,
+        "attempt_id": image_core_id + 1000,
+        "callback_token": f"signed-token-{image_core_id}",
+    }
+
+
 class TestHomeEndpoint:
     """Test suite for GET / endpoint"""
 
@@ -59,11 +69,7 @@ class TestAddJobEndpoint:
     def test_add_job_success(self, mock_status_sender, client, test_db):
         """Test successful job addition"""
         # Setup
-        job_data = {
-            "image_core_id": 1,
-            "image_path": "/path/to/image.jpg",
-            "model": "test"
-        }
+        job_data = job_payload(1)
 
         # Execute
         response = client.post("/add_job", json=job_data)
@@ -74,7 +80,7 @@ class TestAddJobEndpoint:
 
         # Assert status_sender called
         mock_status_sender.assert_called_once_with(
-            {"image_core_id": 1, "status": 1},
+            {"image_core_id": 1, "status": 1, "attempt_id": 1001, "callback_token": "signed-token-1"},
             "http://localhost:3000/"
         )
 
@@ -94,19 +100,11 @@ class TestAddJobEndpoint:
     def test_add_job_multiple_jobs(self, mock_status_sender, client, test_db):
         """Test adding multiple jobs in sequence"""
         # Add first job
-        response1 = client.post("/add_job", json={
-            "image_core_id": 1,
-            "image_path": "/image1.jpg",
-            "model": "test"
-        })
+        response1 = client.post("/add_job", json=job_payload(1, "/image1.jpg"))
         assert response1.status_code == 200
 
         # Add second job
-        response2 = client.post("/add_job", json={
-            "image_core_id": 2,
-            "image_path": "/image2.jpg",
-            "model": "Florence-2-base"
-        })
+        response2 = client.post("/add_job", json=job_payload(2, "/image2.jpg", "Florence-2-base"))
         assert response2.status_code == 200
 
         # Verify both jobs in database
@@ -125,18 +123,31 @@ class TestAddJobEndpoint:
         response = client.post("/add_job", json={
             "image_core_id": 1,
             "image_path": "/image.jpg",
-            "model": "invalid-model-name"
+            "model": "invalid-model-name",
+            "attempt_id": 1001,
+            "callback_token": "signed-token-1"
         })
 
         # FastAPI will return 422 for validation error
         assert response.status_code == 422
 
     @patch('app.status_sender')
+    def test_add_job_requires_attempt_callback_fields(self, mock_status_sender, client):
+        response = client.post("/add_job", json={
+            "image_core_id": 1,
+            "image_path": "/image.jpg",
+            "model": "test"
+        })
+
+        assert response.status_code == 422
+        mock_status_sender.assert_not_called()
+
+    @patch('app.status_sender')
     def test_add_job_batch_from_path_discovery(self, mock_status_sender, client, test_db):
         """Test adding batch of jobs simulating path discovery with multiple images (Scenario A)"""
         # Simulate path with 5 images - all jobs added in quick succession
         batch_jobs = [
-            {"image_core_id": i, "image_path": f"/memes/example_path/image_{i}.jpg", "model": "test"}
+            job_payload(i, f"/memes/example_path/image_{i}.jpg")
             for i in range(1, 6)
         ]
 
@@ -173,9 +184,9 @@ class TestAddJobEndpoint:
     def test_add_job_batch_with_different_models(self, mock_status_sender, client, test_db):
         """Test batch jobs can use different models (user preference per image)"""
         batch_jobs = [
-            {"image_core_id": 1, "image_path": "/image1.jpg", "model": "test"},
-            {"image_core_id": 2, "image_path": "/image2.jpg", "model": "Florence-2-base"},
-            {"image_core_id": 3, "image_path": "/image3.jpg", "model": "Florence-2-large"},
+            job_payload(1, "/image1.jpg"),
+            job_payload(2, "/image2.jpg", "Florence-2-base"),
+            job_payload(3, "/image3.jpg", "Florence-2-large"),
         ]
 
         for job in batch_jobs:
@@ -196,11 +207,7 @@ class TestAddJobEndpoint:
         """Test check_queue correctly reports batch job count"""
         # Add batch of 10 jobs
         for i in range(1, 11):
-            client.post("/add_job", json={
-                "image_core_id": i,
-                "image_path": f"/batch/image_{i}.jpg",
-                "model": "test"
-            })
+            client.post("/add_job", json=job_payload(i, f"/batch/image_{i}.jpg"))
 
         # Check queue
         response = client.get("/check_queue")
@@ -222,16 +229,8 @@ class TestCheckQueueEndpoint:
     def test_check_queue_with_jobs(self, mock_status_sender, client, test_db):
         """Test check_queue with jobs in queue"""
         # Add jobs
-        client.post("/add_job", json={
-            "image_core_id": 1,
-            "image_path": "/image1.jpg",
-            "model": "test"
-        })
-        client.post("/add_job", json={
-            "image_core_id": 2,
-            "image_path": "/image2.jpg",
-            "model": "test"
-        })
+        client.post("/add_job", json=job_payload(1, "/image1.jpg"))
+        client.post("/add_job", json=job_payload(2, "/image2.jpg"))
 
         # Check queue
         response = client.get("/check_queue")
@@ -247,11 +246,7 @@ class TestRemoveJobEndpoint:
     def test_remove_job_success(self, mock_status_sender, client, test_db):
         """Test successful job removal"""
         # Add job first
-        client.post("/add_job", json={
-            "image_core_id": 42,
-            "image_path": "/image.jpg",
-            "model": "test"
-        })
+        client.post("/add_job", json=job_payload(42, "/image.jpg"))
         mock_status_sender.reset_mock()
 
         # Remove job
@@ -263,7 +258,7 @@ class TestRemoveJobEndpoint:
 
         # Assert status_sender called with status=0 (not_started)
         mock_status_sender.assert_called_once_with(
-            {"image_core_id": 42, "status": 0},
+            {"image_core_id": 42, "status": 0, "attempt_id": 1042, "callback_token": "signed-token-42"},
             "http://localhost:3000/"
         )
 
@@ -286,21 +281,13 @@ class TestRemoveJobEndpoint:
         assert response.status_code == 200
         assert response.json() == {"status": "Job removed from queue"}
 
-        # Assert status_sender called with status=3 (done)
-        mock_status_sender.assert_called_once_with(
-            {"image_core_id": 999, "status": 3},
-            "http://localhost:3000/"
-        )
+        mock_status_sender.assert_not_called()
 
     @patch('app.status_sender')
     def test_remove_job_multiple_times(self, mock_status_sender, client, test_db):
         """Test removing same job multiple times"""
         # Add job
-        client.post("/add_job", json={
-            "image_core_id": 10,
-            "image_path": "/image.jpg",
-            "model": "test"
-        })
+        client.post("/add_job", json=job_payload(10, "/image.jpg"))
         mock_status_sender.reset_mock()
 
         # Remove job first time (exists)
@@ -314,5 +301,4 @@ class TestRemoveJobEndpoint:
         # Remove job second time (doesn't exist)
         response2 = client.delete("/remove_job/10")
         assert response2.status_code == 200
-        call_args_2 = mock_status_sender.call_args[0][0]
-        assert call_args_2["status"] == 3  # done
+        mock_status_sender.assert_not_called()

--- a/meme_search/meme_search_app/app/controllers/image_cores_controller.rb
+++ b/meme_search/meme_search_app/app/controllers/image_cores_controller.rb
@@ -8,44 +8,73 @@ class ImageCoresController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [ :description_receiver, :status_receiver ]
 
   def status_receiver
-    received_data = params[:data]
-    id = received_data[:image_core_id].to_i
-    status = received_data[:status].to_i
-    image_core = ImageCore.find(id)
-    image_core.status = status
-    img_id = image_core.id
-    div_id = "status-image-core-id-#{image_core.id}"
-    if image_core.save
+    attempt = verified_callback_attempt
+    return head :unauthorized unless attempt
+
+    status = callback_data[:status].to_i
+    changed =
+      case status
+      when ImageCore.statuses[:not_started]
+        attempt.cancel!
+      when ImageCore.statuses[:in_queue]
+        attempt.mark_queued!
+      when ImageCore.statuses[:processing]
+        attempt.transition_to_processing!
+      when ImageCore.statuses[:done]
+        attempt.active?
+      when ImageCore.statuses[:failed]
+        attempt.fail_with_error!(callback_data[:error_message].presence || "Local image description generation failed.")
+      else
+        return head :unprocessable_entity
+      end
+
+    if changed
+      image_core = attempt.image_core.reload
+      img_id = image_core.id
+      div_id = "status-image-core-id-#{image_core.id}"
       status_html = ApplicationController.renderer.render(partial: "image_cores/generate_status", locals: { img_id: img_id, div_id: div_id, status: image_core.status })
       ActionCable.server.broadcast "image_status_channel", { div_id: div_id, status_html: status_html }
-    else
     end
+
+    head :ok
   end
 
   def description_receiver
-    received_data = params[:data]
-    id = received_data[:image_core_id].to_i
-    description = received_data[:description]
+    attempt = verified_callback_attempt
+    return head :unauthorized unless attempt
 
-    image_core = ImageCore.find(id)
-    image_core.description = description
-    div_id = "description-image-core-id-#{image_core.id}"
+    description = callback_data[:description]
 
-    if image_core.save
+    if attempt.succeed_with_description!(description)
+      image_core = attempt.image_core.reload
+      div_id = "description-image-core-id-#{image_core.id}"
       # update view with newly generated description
       ActionCable.server.broadcast "image_description_channel", { div_id: div_id, description: description }
 
       # re-compute embeddings
       image_core.refresh_description_embeddings
-    else
-      puts "Error updating description: #{image.errors.full_messages.join(", ")}"
     end
+
+    head :ok
   end
 
   def generate_description
     status = @image_core.status
     if status != "in_queue" && status != "processing"
-      result = image_description_provider.generate(@image_core)
+      configuration = ImageDescriptionProviders::Configuration.current
+      provider = ImageDescriptionProviders::Factory.build(configuration)
+      result =
+        if provider.queued_provider?
+          provider.generate(@image_core)
+        else
+          attempt = @image_core.start_description_generation_attempt!(
+            provider: provider_name(provider, configuration),
+            provider_settings: configuration.job_options
+          )
+          @image_core.update!(status: :in_queue)
+          GenerateImageDescriptionJob.perform_later(@image_core.id, configuration.job_options, attempt.id)
+          ImageDescriptionProviders::Result.new(success: true, message: "Queued description generation.", queued: true)
+        end
 
       respond_to do |format|
         if result.success?
@@ -72,9 +101,7 @@ class ImageCoresController < ApplicationController
     status = @image_core.status
     if status == "in_queue"
       if queued_provider_for_cancel?(@image_core)
-        # update status of instance
-        @image_core.status = 4
-        @image_core.save!
+        @image_core.cancel_active_description_generation_attempt!
 
         # send request
         uri = URI.parse("http://image_to_text_generator:8000/remove_job/#{@image_core.id}")
@@ -95,7 +122,7 @@ class ImageCoresController < ApplicationController
           end
         end
       else
-        @image_core.update!(status: :not_started)
+        @image_core.cancel_active_description_generation_attempt!
         respond_to do |format|
           flash[:notice] = "Removed from process queue."
           format.html { redirect_back_or_to root_path }
@@ -123,27 +150,24 @@ class ImageCoresController < ApplicationController
     configuration = ImageDescriptionProviders::Configuration.current
     provider = ImageDescriptionProviders::Factory.build(configuration)
     provider_job_options = configuration.job_options
-
-    # Store operation metadata in session
-    session[:bulk_operation] = {
-      total_count: images_without_descriptions.count,
-      started_at: Time.current.to_i,
-      image_ids: images_without_descriptions.pluck(:id),  # Track specific images in this operation
+    operation = ImageDescriptionBulkOperation.create!(
+      provider: provider_name(provider, configuration),
       provider_queued: provider.queued_provider?,
+      total_count: images_without_descriptions.count,
+      started_at: Time.current,
       filter_params: {
         selected_tag_names: params[:selected_tag_names],
         selected_path_names: params[:selected_path_names],
         has_embeddings: params[:has_embeddings]
       }
-    }
+    )
 
-    # Queue all images for description generation
     queued_count = 0
     failed_count = 0
 
     images_without_descriptions.each do |image_core|
       if provider.queued_provider?
-        result = provider.generate(image_core)
+        result = provider.generate(image_core, bulk_operation: operation)
         if result.success?
           queued_count += 1
         else
@@ -151,8 +175,13 @@ class ImageCoresController < ApplicationController
         end
       else
         begin
+          attempt = image_core.start_description_generation_attempt!(
+            provider: provider_name(provider, configuration),
+            provider_settings: provider_job_options,
+            bulk_operation: operation
+          )
           image_core.update!(status: :in_queue)
-          GenerateImageDescriptionJob.perform_later(image_core.id, provider_job_options)
+          GenerateImageDescriptionJob.perform_later(image_core.id, provider_job_options, attempt.id)
           queued_count += 1
         rescue StandardError => e
           Rails.logger.error "Failed to enqueue image description job for image #{image_core.id}: #{e.class}: #{e.message}"
@@ -177,100 +206,42 @@ class ImageCoresController < ApplicationController
   end
 
   def bulk_operation_status
-    # Get filtered image cores based on session filter params
-    if session[:bulk_operation].present?
-      # DEBUG: Log session contents
-      Rails.logger.info "[BULK DEBUG] session[:bulk_operation]: #{session[:bulk_operation].inspect}"
+    operation = ImageDescriptionBulkOperation.current
+    return render json: { error: "No bulk operation in progress" }, status: :not_found unless operation
 
-      filter_params = session[:bulk_operation]["filter_params"]
-      started_at = session[:bulk_operation]["started_at"]
-      total_count = session[:bulk_operation]["total_count"]
-      image_ids = session[:bulk_operation]["image_ids"] || []
-
-      Rails.logger.info "[BULK DEBUG] total_count extracted: #{total_count.inspect}"
-      Rails.logger.info "[BULK DEBUG] started_at extracted: #{started_at.inspect}"
-      Rails.logger.info "[BULK DEBUG] image_ids extracted: #{image_ids.inspect}"
-
-      # Only count images that were part of this bulk operation
-      operation_images = ImageCore.where(id: image_ids)
-
-      Rails.logger.info "[BULK DEBUG] operation_images count: #{operation_images.count}"
-
-      # Count by status (only for images in this operation)
-      status_counts = {
-        not_started: operation_images.where(status: 0).count,
-        in_queue: operation_images.where(status: 1).count,
-        processing: operation_images.where(status: 2).count,
-        done: operation_images.where(status: 3).count,
-        failed: operation_images.where(status: 5).count
-      }
-
-      Rails.logger.info "[BULK DEBUG] status_counts: #{status_counts.inspect}"
-
-      # Check if operation is complete
-      active_count = status_counts[:in_queue] + status_counts[:processing]
-      is_complete = active_count == 0 && status_counts[:not_started] == 0
-
-      # Prepare response BEFORE clearing session
-      response_data = {
-        status_counts: status_counts,
-        total: total_count,
-        is_complete: is_complete,
-        started_at: started_at
-      }
-
-      # Clear session if complete
-      session.delete(:bulk_operation) if is_complete
-
-      render json: response_data
-    else
-      render json: { error: "No bulk operation in progress" }, status: :not_found
-    end
+    render json: operation.mark_completed_if_finished!
   end
 
   def bulk_operation_cancel
-    if session[:bulk_operation].present?
-      image_ids = session[:bulk_operation][:image_ids] || session[:bulk_operation]["image_ids"] || []
-      image_cores = ImageCore.where(id: image_ids)
+    operation = ImageDescriptionBulkOperation.current
+    return render json: { error: "No bulk operation in progress" }, status: :not_found unless operation
 
-      # Cancel all in_queue images
-      in_queue_images = image_cores.where(status: 1)
-      cancelled_count = 0
+    in_queue_images = operation.image_cores.where(status: ImageCore.statuses[:in_queue])
+    cancelled_count = 0
 
-      in_queue_images.each do |image_core|
-        begin
-          if queued_provider_for_cancel?(image_core)
-            # Update status to removing
-            image_core.update(status: 4)
+    in_queue_images.each do |image_core|
+      begin
+        if operation.provider_queued?
+          image_core.cancel_active_description_generation_attempt!
 
-            # Send remove request to Python service
-            uri = URI("http://image_to_text_generator:8000/remove_job/#{image_core.id}")
-            http = Net::HTTP.new(uri.host, uri.port)
-            request = Net::HTTP::Delete.new(uri.request_uri)
-            request["Content-Type"] = "application/json"
-            response = http.request(request)
+          uri = URI("http://image_to_text_generator:8000/remove_job/#{image_core.id}")
+          http = Net::HTTP.new(uri.host, uri.port)
+          request = Net::HTTP::Delete.new(uri.request_uri)
+          request["Content-Type"] = "application/json"
+          response = http.request(request)
 
-            if response.is_a?(Net::HTTPSuccess)
-              # Reset to not_started after successful removal
-              image_core.update(status: 0)
-              cancelled_count += 1
-            end
-          else
-            image_core.update(status: :not_started)
-            cancelled_count += 1
-          end
-        rescue => e
-          Rails.logger.error "Failed to cancel job for image #{image_core.id}: #{e.message}"
+          cancelled_count += 1 if response.is_a?(Net::HTTPSuccess)
+        else
+          cancelled_count += 1 if image_core.cancel_active_description_generation_attempt!
         end
+      rescue => e
+        Rails.logger.error "Failed to cancel job for image #{image_core.id}: #{e.message}"
       end
-
-      # Clear session
-      session.delete(:bulk_operation)
-
-      render json: { cancelled_count: cancelled_count }
-    else
-      render json: { error: "No bulk operation in progress" }, status: :not_found
     end
+
+    operation.cancel!
+
+    render json: { cancelled_count: cancelled_count }
   end
 
   def search
@@ -409,16 +380,13 @@ class ImageCoresController < ApplicationController
     end
 
     def queued_provider_for_cancel?(image_core)
-      return image_description_provider.queued_provider? unless session[:bulk_operation].present?
+      image_description_provider.queued_provider?
+    end
 
-      image_ids = session[:bulk_operation][:image_ids] || session[:bulk_operation]["image_ids"] || []
-      return image_description_provider.queued_provider? unless image_ids.map(&:to_i).include?(image_core.id)
+    def provider_name(provider, configuration)
+      return provider.name if provider.respond_to?(:name)
 
-      provider_queued = session[:bulk_operation][:provider_queued]
-      provider_queued = session[:bulk_operation]["provider_queued"] if provider_queued.nil?
-      return image_description_provider.queued_provider? if provider_queued.nil?
-
-      ActiveModel::Type::Boolean.new.cast(provider_queued)
+      configuration.provider
     end
 
     def get_filtered_image_cores(filter_params = nil)
@@ -518,6 +486,19 @@ class ImageCoresController < ApplicationController
 
       permitted_params.delete(:selected_tag_names)
       permitted_params
+    end
+
+    def callback_data
+      params.fetch(:data, {})
+    end
+
+    def verified_callback_attempt
+      data = callback_data
+      ImageDescriptionGenerationAttempt.find_verified_callback_attempt(
+        attempt_id: data[:attempt_id],
+        image_core_id: data[:image_core_id],
+        callback_token: data[:callback_token]
+      )
     end
 
   def remove_stopwords(input_string)

--- a/meme_search/meme_search_app/app/javascript/controllers/bulk_progress_controller.js
+++ b/meme_search/meme_search_app/app/javascript/controllers/bulk_progress_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
   ];
 
   static values = {
-    sessionActive: Boolean
+    operationActive: Boolean
   };
 
   connect() {
@@ -29,8 +29,8 @@ export default class extends Controller {
     // Restore state from localStorage
     this.restoreState();
 
-    // Start polling if session is active or localStorage indicates active operation
-    if (this.sessionActiveValue || this.isOperationActive()) {
+    // Start polling if the server has an active operation or localStorage indicates active operation
+    if (this.operationActiveValue || this.isOperationActive()) {
       this.showOverlay();
       this.startPolling();
     }

--- a/meme_search/meme_search_app/app/jobs/generate_image_description_job.rb
+++ b/meme_search/meme_search_app/app/jobs/generate_image_description_job.rb
@@ -3,10 +3,13 @@
 class GenerateImageDescriptionJob < ApplicationJob
   queue_as :default
 
-  def perform(image_core_id, provider_options = nil)
+  def perform(image_core_id, provider_options = nil, attempt_id = nil)
     image_core = ImageCore.find_by(id: image_core_id)
     return unless image_core
     return unless image_core.in_queue?
+    attempt = ImageDescriptionGenerationAttempt.find_by(id: attempt_id)
+    return unless attempt&.image_core_id == image_core.id
+    return unless attempt.active_for_image?
 
     configuration =
       if provider_options.present?
@@ -15,6 +18,6 @@ class GenerateImageDescriptionJob < ApplicationJob
         ImageDescriptionProviders::Configuration.current
       end
 
-    ImageDescriptionProviders::Factory.build(configuration).generate(image_core)
+    ImageDescriptionProviders::Factory.build(configuration).generate(image_core, attempt: attempt)
   end
 end

--- a/meme_search/meme_search_app/app/models/image_core.rb
+++ b/meme_search/meme_search_app/app/models/image_core.rb
@@ -15,6 +15,8 @@ class ImageCore < ApplicationRecord
   # tag association + lookup scope
   belongs_to :image_path
   has_many :image_tags, dependent: :destroy
+  has_many :image_description_generation_attempts, dependent: :destroy
+  has_many :image_description_bulk_operations, through: :image_description_generation_attempts
   accepts_nested_attributes_for :image_tags, allow_destroy: true
 
   # tag lookup scope
@@ -49,6 +51,36 @@ class ImageCore < ApplicationRecord
 
   # before save create description embeddings
   # before_save :refresh_description_embeddings
+
+  def self.delete_all(*args)
+    ImageDescriptionGenerationAttempt.where(image_core_id: all.select(:id)).delete_all
+    super
+  end
+
+  def active_description_generation_attempt
+    image_description_generation_attempts.active.order(created_at: :desc).first
+  end
+
+  def start_description_generation_attempt!(provider:, provider_settings: {}, bulk_operation: nil)
+    with_lock do
+      active_attempt = active_description_generation_attempt
+      raise ActiveRecord::RecordInvalid, active_attempt if active_attempt.present?
+
+      image_description_generation_attempts.create!(
+        provider: provider,
+        provider_settings: provider_settings,
+        image_description_bulk_operation: bulk_operation,
+        status: :queued
+      )
+    end
+  end
+
+  def cancel_active_description_generation_attempt!
+    attempt = active_description_generation_attempt
+    return false unless attempt
+
+    attempt.cancel!
+  end
 
   def remove_image_text_job
     # send request

--- a/meme_search/meme_search_app/app/models/image_description_bulk_operation.rb
+++ b/meme_search/meme_search_app/app/models/image_description_bulk_operation.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ImageDescriptionBulkOperation < ApplicationRecord
+  has_many :image_description_generation_attempts, dependent: :nullify
+  has_many :image_cores, through: :image_description_generation_attempts
+
+  enum :status, {
+    active: 0,
+    completed: 1,
+    canceled: 2
+  }
+
+  validates :provider, presence: true, inclusion: { in: %w[local openai] }
+  validates :total_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :started_at, presence: true
+
+  scope :current_first, -> { active.order(created_at: :desc, id: :desc) }
+
+  def self.current
+    current_first.first
+  end
+
+  def status_snapshot
+    operation_images = image_cores
+    status_counts = {
+      not_started: operation_images.where(status: ImageCore.statuses[:not_started]).count,
+      in_queue: operation_images.where(status: ImageCore.statuses[:in_queue]).count,
+      processing: operation_images.where(status: ImageCore.statuses[:processing]).count,
+      done: operation_images.where(status: ImageCore.statuses[:done]).count,
+      failed: operation_images.where(status: ImageCore.statuses[:failed]).count
+    }
+    active_count = status_counts[:in_queue] + status_counts[:processing]
+    complete = active_count.zero? && status_counts[:not_started].zero?
+    complete = true if total_count.zero?
+
+    {
+      status_counts: status_counts,
+      total: total_count,
+      is_complete: complete,
+      started_at: started_at.to_i
+    }
+  end
+
+  def mark_completed_if_finished!
+    snapshot = status_snapshot
+    update!(status: :completed, completed_at: Time.current) if snapshot[:is_complete] && active?
+    snapshot
+  end
+
+  def cancel!
+    update!(status: :canceled, canceled_at: Time.current, completed_at: Time.current)
+  end
+end

--- a/meme_search/meme_search_app/app/models/image_description_generation_attempt.rb
+++ b/meme_search/meme_search_app/app/models/image_description_generation_attempt.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+class ImageDescriptionGenerationAttempt < ApplicationRecord
+  belongs_to :image_core
+  belongs_to :image_description_bulk_operation, optional: true
+
+  enum :status, {
+    queued: 0,
+    processing: 1,
+    succeeded: 2,
+    failed: 3,
+    canceled: 4
+  }
+
+  ACTIVE_STATUSES = %w[queued processing].freeze
+
+  validates :provider, presence: true, inclusion: { in: %w[local openai] }
+  validates :status, presence: true
+
+  scope :active, -> { where(status: ACTIVE_STATUSES.map { |status| statuses.fetch(status) }) }
+
+  def active?
+    ACTIVE_STATUSES.include?(status)
+  end
+
+  def active_for_image?
+    image_core_id.present? && active? && self.class.active.where(id: id, image_core_id: image_core_id).exists?
+  end
+
+  def callback_token
+    self.class.callback_verifier.generate({
+      "attempt_id" => id,
+      "image_core_id" => image_core_id
+    })
+  end
+
+  def self.find_verified_callback_attempt(attempt_id:, image_core_id:, callback_token:)
+    return nil if attempt_id.blank? || image_core_id.blank? || callback_token.blank?
+
+    payload = callback_verifier.verify(callback_token)
+    return nil unless payload.fetch("attempt_id").to_i == attempt_id.to_i
+    return nil unless payload.fetch("image_core_id").to_i == image_core_id.to_i
+
+    find_by(id: attempt_id, image_core_id: image_core_id)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError
+    nil
+  end
+
+  def self.callback_verifier
+    Rails.application.message_verifier(:image_description_generation_callback)
+  end
+
+  def mark_queued!
+    guarded_update do |attempt, image|
+      image.update!(status: :in_queue) unless image.in_queue?
+      attempt.update!(status: :queued) unless attempt.queued?
+    end
+  end
+
+  def transition_to_processing!
+    guarded_update do |attempt, image|
+      image.update!(status: :processing) unless image.processing?
+      attempt.update!(
+        status: :processing,
+        started_at: attempt.started_at || Time.current
+      )
+    end
+  end
+
+  def succeed_with_description!(description)
+    guarded_update do |attempt, image|
+      image.update!(description: description, status: :done)
+      attempt.update!(status: :succeeded, completed_at: Time.current)
+    end
+  end
+
+  def fail_with_error!(message)
+    guarded_update do |attempt, image|
+      image.update!(status: :failed)
+      attempt.update!(status: :failed, error_message: message, completed_at: Time.current)
+    end
+  end
+
+  def cancel!
+    guarded_update do |attempt, image|
+      image.update!(status: :not_started) if image.in_queue? || image.removing?
+      attempt.update!(status: :canceled, canceled_at: Time.current, completed_at: Time.current)
+    end
+  end
+
+  private
+
+    def guarded_update
+      self.class.transaction do
+        locked_attempt = self.class.lock.find_by(id: id)
+        return false unless locked_attempt&.active?
+
+        locked_image = ImageCore.lock.find_by(id: locked_attempt.image_core_id)
+        return false unless locked_image&.active_description_generation_attempt&.id == locked_attempt.id
+
+        yield locked_attempt, locked_image
+      end
+
+      reload
+      true
+    end
+end

--- a/meme_search/meme_search_app/app/services/image_description_providers/factory.rb
+++ b/meme_search/meme_search_app/app/services/image_description_providers/factory.rb
@@ -4,10 +4,12 @@ module ImageDescriptionProviders
   class Factory
     def self.build(configuration = Configuration.current)
       case configuration.provider.to_s.downcase
+      when "local", ""
+        LocalProvider.new
       when "openai"
         OpenaiProvider.new(configuration)
       else
-        LocalProvider.new
+        raise ArgumentError, "Unknown image description provider: #{configuration.provider}"
       end
     end
   end

--- a/meme_search/meme_search_app/app/services/image_description_providers/local_provider.rb
+++ b/meme_search/meme_search_app/app/services/image_description_providers/local_provider.rb
@@ -17,10 +17,15 @@ module ImageDescriptionProviders
       true
     end
 
-    def generate(image_core)
-      image_core.update(status: :in_queue)
-
+    def generate(image_core, bulk_operation: nil)
       current_model = ImageToText.find_by(current: true)
+      attempt = image_core.start_description_generation_attempt!(
+        provider: name,
+        provider_settings: { model: current_model&.name }.compact,
+        bulk_operation: bulk_operation
+      )
+      image_core.update!(status: :in_queue)
+
       uri = URI(ADD_JOB_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.open_timeout = 5
@@ -31,7 +36,9 @@ module ImageDescriptionProviders
       request.body = {
         image_core_id: image_core.id,
         image_path: "#{image_core.image_path.name}/#{image_core.name}",
-        model: current_model&.name
+        model: current_model&.name,
+        attempt_id: attempt.id,
+        callback_token: attempt.callback_token
       }.to_json
 
       response = http.request(request)
@@ -39,12 +46,13 @@ module ImageDescriptionProviders
       if response.is_a?(Net::HTTPSuccess)
         Result.new(success: true, message: nil, queued: true)
       else
-        image_core.update(status: :failed)
+        attempt.fail_with_error!("Local image to text generator returned #{response.code} #{response.message}.")
         Result.new(success: false, message: "Cannot generate description, your image to text genertaor is offline!", queued: true)
       end
     rescue StandardError => e
       Rails.logger.error "Failed to queue image #{image_core.id}: #{e.class}: #{e.message}"
-      image_core.update(status: :failed)
+      attempt&.fail_with_error!(e.message)
+      image_core.update(status: :failed) unless attempt
       Result.new(success: false, message: "Cannot generate description, your image to text genertaor is offline!", queued: true)
     end
   end

--- a/meme_search/meme_search_app/app/services/image_description_providers/openai_provider.rb
+++ b/meme_search/meme_search_app/app/services/image_description_providers/openai_provider.rb
@@ -80,26 +80,30 @@ module ImageDescriptionProviders
       Result.new(success: false, message: e.message, queued: false)
     end
 
-    def generate(image_core)
-      image_core.update(status: :processing)
+    def generate(image_core, attempt: nil)
+      attempt ||= create_direct_attempt(image_core)
+      return stale_attempt_result unless attempt&.active_for_image?
+      return stale_attempt_result unless attempt.transition_to_processing!
+
+      image_core.reload
       broadcast_status(image_core)
 
       unless api_key.present?
-        return fail_image(image_core, "OpenAI API key is required. Add one in Settings or set OPENAI_API_KEY.")
+        return fail_image(image_core, attempt, "OpenAI API key is required. Add one in Settings or set OPENAI_API_KEY.")
       end
 
       description = normalize_description(request_description(image_core))
       if description.blank?
-        return fail_image(image_core, "OpenAI vision API returned an unsupported response.")
+        return fail_image(image_core, attempt, "OpenAI vision API returned an unsupported response.")
       end
 
-      save_description(image_core, description)
+      save_description(image_core, attempt, description)
       Result.new(success: true, message: "Generated description.", queued: false)
     rescue Net::OpenTimeout, Net::ReadTimeout
-      fail_image(image_core, "OpenAI vision API request timed out.")
+      fail_image(image_core, attempt, "OpenAI vision API request timed out.")
     rescue StandardError => e
       Rails.logger.error "OpenAI image description failed for image #{image_core.id}: #{e.class}: #{e.message}"
-      fail_image(image_core, e.message)
+      fail_image(image_core, attempt, e.message)
     end
 
     private
@@ -171,16 +175,33 @@ module ImageDescriptionProviders
         end
       end
 
-      def save_description(image_core, description)
-        image_core.update!(description: description, status: :done)
+      def create_direct_attempt(image_core)
+        attempt = image_core.start_description_generation_attempt!(
+          provider: name,
+          provider_settings: configuration.job_options
+        )
+        image_core.update!(status: :in_queue)
+        attempt
+      end
+
+      def stale_attempt_result
+        Result.new(success: false, message: "Image description generation attempt is no longer active.", queued: false)
+      end
+
+      def save_description(image_core, attempt, description)
+        return stale_attempt_result unless attempt.succeed_with_description!(description)
+
+        image_core.reload
         div_id = "description-image-core-id-#{image_core.id}"
         ActionCable.server.broadcast "image_description_channel", { div_id: div_id, description: description }
         broadcast_status(image_core)
         image_core.refresh_description_embeddings
       end
 
-      def fail_image(image_core, message)
-        image_core.update(status: :failed)
+      def fail_image(image_core, attempt, message)
+        return stale_attempt_result unless attempt&.fail_with_error!(message)
+
+        image_core.reload
         broadcast_status(image_core)
         Result.new(success: false, message: message, queued: false)
       end

--- a/meme_search/meme_search_app/app/views/image_cores/_bulk_progress.html.erb
+++ b/meme_search/meme_search_app/app/views/image_cores/_bulk_progress.html.erb
@@ -1,9 +1,10 @@
+<% bulk_operation_active = ImageDescriptionBulkOperation.active.exists? %>
 <div
   data-controller="bulk-progress"
-  data-bulk-progress-session-active-value="<%= session[:bulk_operation].present? %>"
+  data-bulk-progress-operation-active-value="<%= bulk_operation_active %>"
   class="fixed bottom-8 right-8 w-96 bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/20 dark:border-white/10 z-50 transition-all duration-300"
   data-bulk-progress-target="overlay"
-  style="<%= 'display: none;' unless session[:bulk_operation].present? %>">
+  style="<%= 'display: none;' unless bulk_operation_active %>">
 
   <!-- Header -->
   <div class="flex items-center justify-between p-4 border-b border-gray-200/50 dark:border-gray-700/50">

--- a/meme_search/meme_search_app/bin/smoke_openai_description
+++ b/meme_search/meme_search_app/bin/smoke_openai_description
@@ -75,8 +75,12 @@ ActiveRecord::Base.transaction do
   image_core = sample_image_core
   puts "ImageCore ##{image_core.id}: #{image_core.image_path.name}/#{image_core.name}"
 
+  attempt = image_core.start_description_generation_attempt!(
+    provider: "openai",
+    provider_settings: configuration.job_options
+  )
   image_core.update!(status: :in_queue, description: nil)
-  provider_result = GenerateImageDescriptionJob.perform_now(image_core.id)
+  provider_result = GenerateImageDescriptionJob.perform_now(image_core.id, configuration.job_options, attempt.id)
 
   image_core.reload
   result = {

--- a/meme_search/meme_search_app/db/migrate/20260524000000_create_image_description_generation_attempts.rb
+++ b/meme_search/meme_search_app/db/migrate/20260524000000_create_image_description_generation_attempts.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateImageDescriptionGenerationAttempts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :image_description_generation_attempts do |t|
+      t.references :image_core, null: false, foreign_key: { on_delete: :cascade }
+      t.string :provider, null: false
+      t.integer :status, null: false, default: 0
+      t.jsonb :provider_settings, null: false, default: {}
+      t.text :error_message
+      t.datetime :started_at
+      t.datetime :completed_at
+      t.datetime :canceled_at
+
+      t.timestamps
+    end
+
+    add_index :image_description_generation_attempts,
+      :image_core_id,
+      unique: true,
+      where: "status IN (0, 1)",
+      name: "index_generation_attempts_one_active_per_image"
+  end
+end

--- a/meme_search/meme_search_app/db/migrate/20260524001000_create_image_description_bulk_operations.rb
+++ b/meme_search/meme_search_app/db/migrate/20260524001000_create_image_description_bulk_operations.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateImageDescriptionBulkOperations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :image_description_bulk_operations do |t|
+      t.string :provider, null: false
+      t.boolean :provider_queued, null: false, default: true
+      t.integer :status, null: false, default: 0
+      t.integer :total_count, null: false, default: 0
+      t.jsonb :filter_params, null: false, default: {}
+      t.datetime :started_at, null: false
+      t.datetime :completed_at
+      t.datetime :canceled_at
+
+      t.timestamps
+    end
+
+    add_reference :image_description_generation_attempts,
+      :image_description_bulk_operation,
+      foreign_key: { on_delete: :nullify },
+      index: { name: "index_generation_attempts_on_bulk_operation_id" }
+  end
+end

--- a/meme_search/meme_search_app/db/schema.rb
+++ b/meme_search/meme_search_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_23_220000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_24_001000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -39,6 +39,36 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_23_220000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["image_path_id"], name: "index_image_cores_on_image_path_id"
+  end
+
+  create_table "image_description_bulk_operations", force: :cascade do |t|
+    t.string "provider", null: false
+    t.boolean "provider_queued", default: true, null: false
+    t.integer "status", default: 0, null: false
+    t.integer "total_count", default: 0, null: false
+    t.jsonb "filter_params", default: {}, null: false
+    t.datetime "started_at", null: false
+    t.datetime "completed_at"
+    t.datetime "canceled_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "image_description_generation_attempts", force: :cascade do |t|
+    t.bigint "image_core_id", null: false
+    t.string "provider", null: false
+    t.integer "status", default: 0, null: false
+    t.jsonb "provider_settings", default: {}, null: false
+    t.text "error_message"
+    t.datetime "started_at"
+    t.datetime "completed_at"
+    t.datetime "canceled_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "image_description_bulk_operation_id"
+    t.index ["image_core_id"], name: "index_generation_attempts_one_active_per_image", unique: true, where: "(status = ANY (ARRAY[0, 1]))"
+    t.index ["image_core_id"], name: "index_image_description_generation_attempts_on_image_core_id"
+    t.index ["image_description_bulk_operation_id"], name: "index_generation_attempts_on_bulk_operation_id"
   end
 
   create_table "image_embeddings", force: :cascade do |t|
@@ -213,6 +243,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_23_220000) do
   end
 
   add_foreign_key "image_cores", "image_paths"
+  add_foreign_key "image_description_generation_attempts", "image_cores"
+  add_foreign_key "image_description_generation_attempts", "image_description_bulk_operations", on_delete: :nullify
   add_foreign_key "image_embeddings", "image_cores"
   add_foreign_key "image_tags", "image_cores"
   add_foreign_key "image_tags", "tag_names"

--- a/meme_search/meme_search_app/test/controllers/concerns/bulk_generation_test_helpers.rb
+++ b/meme_search/meme_search_app/test/controllers/concerns/bulk_generation_test_helpers.rb
@@ -53,27 +53,22 @@ module BulkGenerationTestHelpers
     WebMock.reset!
   end
 
-  # Verify session has correct structure and data types
-  def assert_session_structure(session_data)
-    assert_not_nil session_data, "Session data should exist"
-    assert_instance_of Hash, session_data
-
-    # In tests, controller sets symbol keys which remain as symbols in test session
-    # In production, ActionDispatch::Session converts to strings
-    # Use flexible access for both
-    total_count = session_data[:total_count] || session_data["total_count"]
-    started_at = session_data[:started_at] || session_data["started_at"]
-    image_ids = session_data[:image_ids] || session_data["image_ids"]
-    filter_params = session_data[:filter_params] || session_data["filter_params"]
-
-    # Check data types
-    assert_instance_of Integer, total_count
-    assert_instance_of Integer, started_at
-    assert_instance_of Array, image_ids
-    assert_instance_of Hash, filter_params
+  def current_bulk_operation
+    ImageDescriptionBulkOperation.current
   end
 
-  # Verify image status is in_queue
+  def operation_image_ids(operation)
+    operation.image_cores.pluck(:id)
+  end
+
+  def assert_bulk_operation_structure(operation)
+    assert_not_nil operation, "Bulk operation should exist"
+    assert_instance_of ImageDescriptionBulkOperation, operation
+    assert_instance_of Integer, operation.total_count
+    assert_instance_of ActiveSupport::TimeWithZone, operation.started_at
+    assert_instance_of Hash, operation.filter_params
+  end
+
   def assert_image_queued(image_core)
     image_core.reload
     assert_equal "in_queue", image_core.status, "Image should be in_queue"
@@ -83,23 +78,6 @@ module BulkGenerationTestHelpers
   def assert_image_done(image_core)
     image_core.reload
     assert_equal "done", image_core.status, "Image should be done"
-  end
-
-  # Build session data structure for passing to GET/POST requests
-  # Use this to create session data that you pass to requests via session: parameter
-  def build_bulk_session_data(image_ids:, total_count: nil, filter_params: {})
-    {
-      bulk_operation: {
-        total_count: total_count || image_ids.length,
-        started_at: Time.current.to_i,
-        image_ids: image_ids,
-        filter_params: {
-          selected_tag_names: filter_params[:selected_tag_names] || "",
-          selected_path_names: filter_params[:selected_path_names] || "",
-          has_embeddings: filter_params[:has_embeddings] || ""
-        }
-      }
-    }
   end
 
   # Get status counts from response JSON

--- a/meme_search/meme_search_app/test/controllers/image_cores_controller_bulk_test.rb
+++ b/meme_search/meme_search_app/test/controllers/image_cores_controller_bulk_test.rb
@@ -13,6 +13,7 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     ImageEmbedding.delete_all  # Child first
     ImageTag.delete_all  # Child first
     ImageCore.delete_all  # Parent after children
+    ImageDescriptionBulkOperation.delete_all
     # Keep fixture data, delete only test-created data
     TagName.where("name LIKE 'tag_%' OR name LIKE 'special%' OR name LIKE 'bulk_%'").delete_all
     ImagePath.where("name LIKE 'test_%' OR name LIKE 'special%'").delete_all
@@ -51,17 +52,15 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     # Assert redirects
     assert_redirected_to image_cores_path
 
-    # Assert session structure
-    session_data = session[:bulk_operation]
-    assert_session_structure(session_data)
+    operation = current_bulk_operation
+    assert_bulk_operation_structure(operation)
 
-    # Assert session counts (use symbol keys as controller sets them)
-    assert_equal 3, session_data[:total_count]
-    assert_equal 3, session_data[:image_ids].length
+    assert_equal 3, operation.total_count
+    assert_equal 3, operation_image_ids(operation).length
 
     # Assert image_ids match the queued images
     queued_ids = images_without_desc.map(&:id)
-    assert_equal queued_ids.sort, session_data[:image_ids].sort
+    assert_equal queued_ids.sort, operation_image_ids(operation).sort
 
     # Assert only 3 images were queued
     images_without_desc.each do |img|
@@ -75,25 +74,19 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     end
   end
 
-  # Test 1.2: Session data types (critical for bug prevention!)
-  test "bulk_generate_descriptions should initialize session with correct data types" do
+  # Test 1.2: Durable operation data types (critical for bug prevention!)
+  test "bulk_generate_descriptions should initialize operation with correct data types" do
     setup_bulk_test_images(count: 2, with_descriptions: false)
 
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
 
-    session_data = session[:bulk_operation]
-
-    # Verify it's a Hash
-    assert_instance_of Hash, session_data
-
-    # Access with symbol keys (controller sets them as symbols, Rails may/may not convert in test)
-    # In production, ActionDispatch::Session converts to strings, but in tests we access directly
-    total_count = session_data[:total_count] || session_data["total_count"]
-    started_at = session_data[:started_at] || session_data["started_at"]
-    image_ids = session_data[:image_ids] || session_data["image_ids"]
-    filter_params = session_data[:filter_params] || session_data["filter_params"]
+    operation = current_bulk_operation
+    total_count = operation.total_count
+    started_at = operation.started_at.to_i
+    image_ids = operation_image_ids(operation)
+    filter_params = operation.filter_params
 
     # Verify data types
     assert_instance_of Integer, total_count, "total_count should be Integer not nil!"
@@ -108,7 +101,7 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
   end
 
   # Test 1.3: Image IDs tracking for progress bar
-  test "bulk_generate_descriptions should store image_ids in session for progress tracking" do
+  test "bulk_generate_descriptions should store image ids in operation attempts for progress tracking" do
     # Create 4 specific images
     images = setup_bulk_test_images(count: 4, with_descriptions: false)
 
@@ -116,14 +109,14 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
       post bulk_generate_descriptions_image_cores_url
     end
 
-    session_data = session[:bulk_operation]
+    operation = current_bulk_operation
 
     # Assert image_ids contains exactly 4 IDs
-    assert_equal 4, session_data[:image_ids].length
+    assert_equal 4, operation_image_ids(operation).length
 
     # Assert IDs match the created test images
     expected_ids = images.map(&:id).sort
-    actual_ids = session_data[:image_ids].sort
+    actual_ids = operation_image_ids(operation).sort
     assert_equal expected_ids, actual_ids
 
     # This test validates the fix for the progress bar bug!
@@ -141,10 +134,9 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     # Should still redirect
     assert_redirected_to image_cores_path
 
-    # Should initialize session with 0 count
-    session_data = session[:bulk_operation]
-    assert_equal 0, session_data[:total_count]
-    assert_equal [], session_data[:image_ids]
+    operation = current_bulk_operation
+    assert_equal 0, operation.total_count
+    assert_equal [], operation_image_ids(operation)
   end
 
   # Test 1.5: Nil vs empty string descriptions
@@ -169,8 +161,8 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     end
 
     # Should queue all 4 images (both nil and "" count as "no description")
-    session_data = session[:bulk_operation]
-    assert_equal 4, session_data[:total_count]
+    operation = current_bulk_operation
+    assert_equal 4, operation.total_count
 
     # All 4 should be queued
     (images_nil + images_empty).each do |img|
@@ -193,9 +185,9 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     end
 
     # Should be queued (status=0 takes precedence per OR logic)
-    session_data = session[:bulk_operation]
-    assert_equal 1, session_data[:total_count]
-    assert_includes session_data[:image_ids], img.id
+    operation = current_bulk_operation
+    assert_equal 1, operation.total_count
+    assert_includes operation_image_ids(operation), img.id
     assert_image_queued(img)
   end
 
@@ -219,18 +211,18 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
       post bulk_generate_descriptions_image_cores_url, params: { selected_tag_names: "tag_1" }
     end
 
-    session_data = session[:bulk_operation]
+    operation = current_bulk_operation
 
     # Should only queue 3 images with tag_1
-    assert_equal 3, session_data[:total_count]
-    assert_equal 3, session_data[:image_ids].length
+    assert_equal 3, operation.total_count
+    assert_equal 3, operation_image_ids(operation).length
 
     # Verify correct images queued
     tag_1_ids = images_tag_1.map(&:id).sort
-    assert_equal tag_1_ids, session_data[:image_ids].sort
+    assert_equal tag_1_ids, operation_image_ids(operation).sort
 
-    # Verify filter params stored (use symbol keys throughout)
-    assert_equal "tag_1", session_data[:filter_params][:selected_tag_names]
+    # Verify filter params stored
+    assert_equal "tag_1", operation.filter_params["selected_tag_names"]
   end
 
   # Test 2.2: Path filter
@@ -248,13 +240,13 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
       post bulk_generate_descriptions_image_cores_url, params: { selected_path_names: @image_path.name }
     end
 
-    session_data = session[:bulk_operation]
+    operation = current_bulk_operation
 
     # Should only queue 2 images from path_1
-    assert_equal 2, session_data[:total_count]
+    assert_equal 2, operation.total_count
 
     path_1_ids = images_path_1.map(&:id).sort
-    assert_equal path_1_ids, session_data[:image_ids].sort
+    assert_equal path_1_ids, operation_image_ids(operation).sort
   end
 
   # Test 2.3: has_embeddings filter (value "0" = no embeddings)
@@ -276,13 +268,13 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
       post bulk_generate_descriptions_image_cores_url, params: { has_embeddings: "0" }
     end
 
-    session_data = session[:bulk_operation]
+    operation = current_bulk_operation
 
     # Should only queue 3 images without embeddings
-    assert_equal 3, session_data[:total_count]
+    assert_equal 3, operation.total_count
 
     no_emb_ids = images_no_emb.map(&:id).sort
-    assert_equal no_emb_ids, session_data[:image_ids].sort
+    assert_equal no_emb_ids, operation_image_ids(operation).sort
   end
 
   # Test 2.4: Empty string has_embeddings should not filter (bug fix validation!)
@@ -300,10 +292,10 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
       post bulk_generate_descriptions_image_cores_url, params: { has_embeddings: "" }
     end
 
-    session_data = session[:bulk_operation]
+    operation = current_bulk_operation
 
     # Should queue all 5 images (no filter applied for empty string)
-    assert_equal 5, session_data[:total_count]
+    assert_equal 5, operation.total_count
 
     # This validates the bug fix from lines 432-447!
   end
@@ -346,29 +338,29 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
       }
     end
 
-    session_data = session[:bulk_operation]
+    operation = current_bulk_operation
 
     # Should only queue the one image matching ALL criteria
-    assert_equal 1, session_data[:total_count]
-    assert_equal [ match_img.id ], session_data[:image_ids]
+    assert_equal 1, operation.total_count
+    assert_equal [ match_img.id ], operation_image_ids(operation)
   end
 
   # =============================================================================
   # PHASE 3: bulk_operation_status Tests
   # =============================================================================
 
-  # Test 3.1: Return status when session exists
-  test "bulk_operation_status should return status when session exists" do
+  # Test 3.1: Return status when operation exists
+  test "bulk_operation_status should return status when operation exists" do
     # Create images WITHOUT descriptions so they'll be queued
     images = setup_bulk_test_images(count: 3, with_descriptions: false)
 
-    # POST to bulk_generate_descriptions to create session
+    # POST to bulk_generate_descriptions to create durable operation
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
     assert_redirected_to image_cores_path
 
-    # Now GET status - session should exist from the POST
+    # Now GET status - operation should exist from the POST
     get bulk_operation_status_image_cores_url, as: :json
 
     assert_response :success
@@ -380,18 +372,18 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     assert_not_nil data["started_at"]
   end
 
-  # Test 3.2: Access session with string keys (bug fix validation!)
-  test "bulk_operation_status should access session with string keys not symbol keys" do
+  # Test 3.2: Started-at and total values are durable
+  test "bulk_operation_status should return durable total and started_at values" do
     # Create images WITHOUT descriptions so they'll be queued
     images = setup_bulk_test_images(count: 2, with_descriptions: false)
 
-    # POST to bulk_generate_descriptions to create session with string keys
+    # POST to bulk_generate_descriptions to create durable operation
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
     assert_redirected_to image_cores_path
 
-    # Then make the actual request - tests that controller accesses string keys
+    # Then make the actual request
     get bulk_operation_status_image_cores_url, as: :json
 
     assert_response :success
@@ -406,8 +398,8 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     assert_not_nil data["started_at"], "started_at must not be nil - bug fix validation"
   end
 
-  # Test 3.3: Return error when no session exists
-  test "bulk_operation_status should return error when no session exists" do
+  # Test 3.3: Return error when no active operation exists
+  test "bulk_operation_status should return error when no active operation exists" do
     get bulk_operation_status_image_cores_url, as: :json
 
     assert_response :not_found
@@ -416,25 +408,25 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     assert_includes data["error"], "No bulk operation"
   end
 
-  # Test 3.4: Count only images in image_ids array (progress bar fix!)
-  test "bulk_operation_status should count only images in image_ids array" do
+  # Test 3.4: Count only images attached to the operation
+  test "bulk_operation_status should count only images attached to the operation" do
     # Create images WITHOUT descriptions (will be queued)
-    session_images = setup_bulk_test_images(count: 3, with_descriptions: false)
+    operation_images = setup_bulk_test_images(count: 3, with_descriptions: false)
 
-    # Create image NOT in session (should NOT be counted)
+    # Create image NOT in operation (should NOT be counted)
     # This image gets created and won't be queued in bulk operation
     outside_img = setup_bulk_test_images(count: 1, with_descriptions: true, status: 3).first
 
-    # POST to bulk_generate_descriptions - this queues session_images
+    # POST to bulk_generate_descriptions - this queues operation_images
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
     assert_redirected_to image_cores_path
 
-    # Now update the session images to different statuses
-    session_images[0].update!(status: 3) # done
-    session_images[1].update!(status: 2) # processing
-    session_images[2].update!(status: 1) # in_queue
+    # Now update the operation images to different statuses
+    operation_images[0].update!(status: 3) # done
+    operation_images[1].update!(status: 2) # processing
+    operation_images[2].update!(status: 1) # in_queue
 
     # Get status
     get bulk_operation_status_image_cores_url, as: :json
@@ -444,7 +436,7 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     data = parse_status_response(response)
     status_counts = data["status_counts"]
 
-    # Should count only the 3 images in session, NOT the outside image!
+    # Should count only the 3 images in operation, NOT the outside image!
     assert_equal 1, status_counts["done"], "Only image 1, NOT the outside image!"
     assert_equal 1, status_counts["processing"]
     assert_equal 1, status_counts["in_queue"]
@@ -458,7 +450,7 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     # Create images WITHOUT descriptions (will be queued)
     images = setup_bulk_test_images(count: 3, with_descriptions: false)
 
-    # POST to bulk_generate_descriptions - this queues images and creates session
+    # POST to bulk_generate_descriptions - this queues images and creates durable operation
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
@@ -481,7 +473,7 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     # Create images WITHOUT descriptions (will be queued)
     images = setup_bulk_test_images(count: 4, with_descriptions: false)
 
-    # POST to bulk_generate_descriptions - this queues images and creates session
+    # POST to bulk_generate_descriptions - this queues images and creates durable operation
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
@@ -500,12 +492,12 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     assert_equal false, data["is_complete"], "Should not be complete with active images"
   end
 
-  # Test 3.7: Clear session when complete
-  test "bulk_operation_status should clear session when operation complete" do
+  # Test 3.7: Complete operation when all work is finished
+  test "bulk_operation_status should mark operation complete when operation complete" do
     # Create images without descriptions
     images = setup_bulk_test_images(count: 2, with_descriptions: false)
 
-    # POST to create session
+    # POST to create durable operation
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
@@ -513,22 +505,24 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     # Mark all images as done
     images.each { |img| img.update!(status: "done") }
 
-    # GET status - should clear session since all done
+    operation = current_bulk_operation
+
+    # GET status - should complete operation since all done
     get bulk_operation_status_image_cores_url, as: :json
 
     data = parse_status_response(response)
     assert_equal true, data["is_complete"]
 
-    # Session should be cleared
-    assert_nil session[:bulk_operation], "Session should be cleared when complete"
+    assert_equal "completed", operation.reload.status
+    assert_nil ImageDescriptionBulkOperation.current
   end
 
-  # Test 3.8: Don't clear session when incomplete
-  test "bulk_operation_status should not clear session when incomplete" do
+  # Test 3.8: Keep operation active when incomplete
+  test "bulk_operation_status should keep operation active when incomplete" do
     # Create images WITHOUT descriptions (will be queued)
     images = setup_bulk_test_images(count: 2, with_descriptions: false)
 
-    # POST to bulk_generate_descriptions - this queues images and creates session
+    # POST to bulk_generate_descriptions - this queues images and creates durable operation
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
@@ -544,8 +538,7 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     data = parse_status_response(response)
     assert_equal false, data["is_complete"]
 
-    # Session should still exist
-    assert_not_nil session[:bulk_operation], "Session should persist when incomplete"
+    assert_equal "active", current_bulk_operation.status
   end
 
   # =============================================================================
@@ -553,18 +546,18 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
   # =============================================================================
 
   # Test 4.1: Cancel pending jobs
-  test "bulk_operation_cancel should cancel jobs and clear session" do
+  test "bulk_operation_cancel should cancel jobs and mark operation canceled" do
     # Create images WITHOUT descriptions (will be queued)
     images = setup_bulk_test_images(count: 3, with_descriptions: false)
 
-    # POST to bulk_generate_descriptions - this queues images and creates session
+    # POST to bulk_generate_descriptions - this queues images and creates durable operation
     mock_python_service_success do
       post bulk_generate_descriptions_image_cores_url
     end
     assert_redirected_to image_cores_path
 
-    # Verify session exists before cancel
-    assert_not_nil session[:bulk_operation], "Session should exist after bulk_generate"
+    operation = current_bulk_operation
+    assert_equal "active", operation.status
 
     # Cancel the operation
     mock_python_service_success do
@@ -576,8 +569,8 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     data = parse_status_response(response)
     assert_equal 3, data["cancelled_count"]
 
-    # Session should be cleared
-    assert_nil session[:bulk_operation], "Session should be cleared after cancel"
+    assert_equal "canceled", operation.reload.status
+    assert_nil ImageDescriptionBulkOperation.current
   end
 
   test "bulk_operation_cancel should cancel openai jobs locally" do
@@ -594,12 +587,13 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to image_cores_path
     bulk_provider.verify
+    operation = current_bulk_operation
     unrelated_image = setup_bulk_test_images(count: 1, with_descriptions: false).first
     unrelated_image.update!(status: :in_queue)
 
     cancel_provider = Object.new
     cancel_provider.define_singleton_method(:queued_provider?) do
-      flunk "cancel should use the provider mode captured in the bulk operation session"
+      flunk "cancel should use the provider mode captured in the durable bulk operation"
     end
 
     ImageDescriptionProviders::Factory.stub(:build, cancel_provider) do
@@ -613,16 +607,14 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
       assert_equal "not_started", image.reload.status
     end
     assert_equal "in_queue", unrelated_image.reload.status
-    assert_nil session[:bulk_operation], "Session should be cleared after cancel"
+    assert_equal "canceled", operation.reload.status
+    assert_nil current_bulk_operation
   end
 
-  # Test 4.2: Handle no active session
-  test "bulk_operation_cancel should handle no active session gracefully" do
-    # No session data
-
+  # Test 4.2: Handle no active operation
+  test "bulk_operation_cancel should handle no active operation gracefully" do
     post bulk_operation_cancel_image_cores_url, as: :json
 
-    # Controller returns 404 when no session exists - this is correct behavior
     assert_response :not_found
 
     data = parse_status_response(response)
@@ -652,11 +644,14 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
     # Step 3: Manually complete images
     images.each { |img| img.update!(status: 3, description: "Done") }
 
-    # Step 4: Poll again (should show complete and clear session)
+    operation = current_bulk_operation
+
+    # Step 4: Poll again (should show complete and mark operation complete)
     get bulk_operation_status_image_cores_url, as: :json
     data = parse_status_response(response)
     assert_equal true, data["is_complete"]
-    assert_nil session[:bulk_operation], "Session cleared after completion"
+    assert_equal "completed", operation.reload.status
+    assert_nil current_bulk_operation
   end
 
   # Test 5.2: Full workflow - generate, poll, cancel
@@ -678,8 +673,8 @@ class ImageCoresControllerBulkTest < ActionDispatch::IntegrationTest
       post bulk_operation_cancel_image_cores_url, as: :json
     end
 
-    # Step 4: Verify session cleared
+    # Step 4: Verify operation is no longer active
     get bulk_operation_status_image_cores_url, as: :json
-    assert_response :not_found # No session exists
+    assert_response :not_found
   end
 end

--- a/meme_search/meme_search_app/test/controllers/image_cores_controller_test.rb
+++ b/meme_search/meme_search_app/test/controllers/image_cores_controller_test.rb
@@ -267,24 +267,28 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
     assert_equal "failed", @image_core.reload.status
   end
 
-  test "single image generate description runs openai provider immediately" do
+  test "single image generate description enqueues openai job with an active attempt" do
     image_core = image_cores(:one)
     image_core.update!(description: nil, status: :not_started)
-    result = ImageDescriptionProviders::Result.new(success: true, message: "Generated description.", queued: false)
-    provider = Minitest::Mock.new
-    provider.expect(:generate, result, [ image_core ])
+    provider = Object.new
+    provider.define_singleton_method(:name) { "openai" }
+    provider.define_singleton_method(:queued_provider?) { false }
+    provider.define_singleton_method(:generate) { |_image_core| flunk "openai should be enqueued, not generated inline" }
 
     with_env("IMAGE_DESCRIPTION_PROVIDER" => "openai") do
       ImageDescriptionProviders::Factory.stub(:build, provider) do
-        assert_no_enqueued_jobs do
-          post generate_description_image_core_url(image_core)
+        assert_difference("ImageDescriptionGenerationAttempt.count", 1) do
+          assert_enqueued_jobs 1, only: GenerateImageDescriptionJob do
+            post generate_description_image_core_url(image_core)
+          end
         end
       end
     end
 
     assert_redirected_to root_path
-    assert_equal "Generated description.", flash[:notice]
-    provider.verify
+    assert_equal "Queued description generation.", flash[:notice]
+    assert_equal "in_queue", image_core.reload.status
+    assert_equal "queued", image_core.active_description_generation_attempt.status
   end
 
   test "bulk generate descriptions enqueues jobs for openai provider without calling api inline" do
@@ -294,6 +298,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
     test_case = self
     provider = Object.new
+    provider.define_singleton_method(:name) { "openai" }
     provider.define_singleton_method(:queued_provider?) { false }
     provider.define_singleton_method(:generate) do |_image_core|
       test_case.flunk "provider.generate should not run inline for openai bulk generation"
@@ -301,18 +306,10 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
     with_env("IMAGE_DESCRIPTION_PROVIDER" => "openai") do
       ImageDescriptionProviders::Factory.stub(:build, provider) do
-        assert_enqueued_with(
-          job: GenerateImageDescriptionJob,
-          args: [
-            image_core.id,
-            {
-              "provider" => "openai",
-              "openai_base_url" => DescriptionProviderSetting::DEFAULT_OPENAI_BASE_URL,
-              "openai_model" => DescriptionProviderSetting::DEFAULT_OPENAI_MODEL
-            }
-          ]
-        ) do
-          post bulk_generate_descriptions_image_cores_url
+        assert_difference("ImageDescriptionGenerationAttempt.count", 1) do
+          assert_enqueued_jobs 1, only: GenerateImageDescriptionJob do
+            post bulk_generate_descriptions_image_cores_url
+          end
         end
       end
     end
@@ -320,6 +317,49 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to image_cores_path
     assert_match "Queued 1 images", flash[:notice]
     assert_equal "in_queue", image_core.reload.status
+    assert_equal "queued", image_core.active_description_generation_attempt.status
+  end
+
+  test "bulk generate descriptions passes active attempt id to openai job" do
+    ImageCore.update_all(description: "already described", status: ImageCore.statuses[:done])
+    image_core = image_cores(:one)
+    image_core.update!(description: nil, status: :not_started)
+
+    provider = Object.new
+    provider.define_singleton_method(:name) { "openai" }
+    provider.define_singleton_method(:queued_provider?) { false }
+
+    with_env("IMAGE_DESCRIPTION_PROVIDER" => "openai") do
+      ImageDescriptionProviders::Factory.stub(:build, provider) do
+        post bulk_generate_descriptions_image_cores_url
+      end
+    end
+
+    attempt = image_core.reload.active_description_generation_attempt
+    job_args = enqueued_jobs.last.fetch(:args)
+    assert_equal image_core.id, job_args[0]
+    assert_equal "openai", job_args[1]["provider"]
+    assert_equal attempt.id, job_args[2]
+  end
+
+  test "bulk generate descriptions enqueues openai jobs with non-secret provider settings" do
+    ImageCore.update_all(description: "already described", status: ImageCore.statuses[:done])
+    image_core = image_cores(:one)
+    image_core.update!(description: nil, status: :not_started)
+
+    provider = Object.new
+    provider.define_singleton_method(:name) { "openai" }
+    provider.define_singleton_method(:queued_provider?) { false }
+
+    with_env("IMAGE_DESCRIPTION_PROVIDER" => "openai", "OPENAI_API_KEY" => "secret-test-key") do
+      ImageDescriptionProviders::Factory.stub(:build, provider) do
+          post bulk_generate_descriptions_image_cores_url
+      end
+    end
+
+    job_args = enqueued_jobs.last.fetch(:args)
+    assert_equal "openai", job_args[1]["provider"]
+    assert_not job_args.inspect.include?("secret-test-key")
   end
 
   test "bulk operation cancel uses provider mode captured when operation was queued" do
@@ -329,6 +369,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
     test_case = self
     provider = Object.new
+    provider.define_singleton_method(:name) { "openai" }
     provider.define_singleton_method(:queued_provider?) { false }
     provider.define_singleton_method(:generate) do |_queued_image|
       test_case.flunk "provider.generate should not run inline for openai bulk generation"
@@ -356,6 +397,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
   # Generate stopper tests
   test "generate_stopper should remove job from queue" do
     @image_core.update!(status: :in_queue)
+    @image_core.start_description_generation_attempt!(provider: "local")
 
     mock_response = Minitest::Mock.new
     mock_response.expect(:is_a?, true, [ Net::HTTPSuccess ])
@@ -370,13 +412,15 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
     end
 
     @image_core.reload
-    assert_equal "removing", @image_core.status
+    assert_equal "not_started", @image_core.status
+    assert_equal "canceled", @image_core.image_description_generation_attempts.last.status
   end
 
   test "generate_stopper should cancel openai queued job locally" do
     @image_core.update!(status: :in_queue)
     provider = Minitest::Mock.new
     provider.expect(:queued_provider?, false)
+    @image_core.start_description_generation_attempt!(provider: "openai")
 
     with_env("IMAGE_DESCRIPTION_PROVIDER" => "openai") do
       ImageDescriptionProviders::Factory.stub(:build, provider) do
@@ -401,6 +445,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
   # Webhook receiver tests
   test "description_receiver should update description and broadcast" do
     new_description = "AI generated description"
+    attempt = local_attempt_for(@image_core)
 
     # Mock ActionCable broadcast
     ActionCable.server.stub(:broadcast, ->(channel, data) {
@@ -410,7 +455,9 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
       post description_receiver_image_cores_url, params: {
         data: {
           image_core_id: @image_core.id,
-          description: new_description
+          description: new_description,
+          attempt_id: attempt.id,
+          callback_token: attempt.callback_token
         }
       }
     end
@@ -422,6 +469,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
   test "description_receiver should refresh embeddings" do
     # Mock the ImageCore instance to stub refresh_description_embeddings
     mock_image_core = @image_core
+    attempt = local_attempt_for(mock_image_core)
     mock_image_core.stub(:refresh_description_embeddings, -> {
       # Verify this is called
     }) do
@@ -429,7 +477,9 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
         post description_receiver_image_cores_url, params: {
           data: {
             image_core_id: @image_core.id,
-            description: "New description"
+            description: "New description",
+            attempt_id: attempt.id,
+            callback_token: attempt.callback_token
           }
         }
         # Verify the request succeeded
@@ -440,6 +490,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
   test "status_receiver should update status and broadcast" do
     new_status = 3 # done
+    attempt = local_attempt_for(@image_core)
 
     # Mock ActionCable broadcast
     ActionCable.server.stub(:broadcast, ->(channel, data) {
@@ -448,13 +499,15 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
       post status_receiver_image_cores_url, params: {
         data: {
           image_core_id: @image_core.id,
-          status: new_status
+          status: new_status,
+          attempt_id: attempt.id,
+          callback_token: attempt.callback_token
         }
       }
     end
 
     @image_core.reload
-    assert_equal "done", @image_core.status
+    assert_equal "in_queue", @image_core.status
   end
 
   # Rate limiting tests
@@ -499,11 +552,14 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
     image_core = image_cores(:one)
     original_description = image_core.description
     new_description = "A cat sitting on a laptop with funny text"
+    attempt = local_attempt_for(image_core)
 
     post description_receiver_image_cores_url, params: {
       data: {
         image_core_id: image_core.id,
-        description: new_description
+        description: new_description,
+        attempt_id: attempt.id,
+        callback_token: attempt.callback_token
       }
     }, as: :json
 
@@ -515,12 +571,15 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
   test "description_receiver should broadcast to image_description_channel" do
     image_core = image_cores(:one)
     description = "AI generated description"
+    attempt = local_attempt_for(image_core)
 
     assert_broadcasts "image_description_channel", 1 do
       post description_receiver_image_cores_url, params: {
         data: {
           image_core_id: image_core.id,
-          description: description
+          description: description,
+          attempt_id: attempt.id,
+          callback_token: attempt.callback_token
         }
       }, as: :json
     end
@@ -528,6 +587,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
   test "description_receiver should refresh description embeddings" do
     image_core = image_cores(:one)
+    attempt = local_attempt_for(image_core)
 
     # Create initial embedding
     original_embedding = ImageEmbedding.create!(
@@ -555,7 +615,9 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
     post description_receiver_image_cores_url, params: {
       data: {
         image_core_id: image_core.id,
-        description: long_description
+        description: long_description,
+        attempt_id: attempt.id,
+        callback_token: attempt.callback_token
       }
     }, as: :json
 
@@ -571,13 +633,16 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
   test "description_receiver should skip CSRF token verification" do
     image_core = image_cores(:one)
+    attempt = local_attempt_for(image_core)
 
     # Post without CSRF token (would normally fail)
     assert_nothing_raised do
       post description_receiver_image_cores_url, params: {
         data: {
           image_core_id: image_core.id,
-          description: "Test description"
+          description: "Test description",
+          attempt_id: attempt.id,
+          callback_token: attempt.callback_token
         }
       }, as: :json
     end
@@ -589,12 +654,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
   # PHASE 2: description_receiver error cases
 
-  test "description_receiver should handle missing image_core_id" do
-    # Current behavior: params[:data][:image_core_id] is nil
-    # .to_i on nil returns 0, then find(0) raises RecordNotFound
-    # Rails rescues and returns 404 Not Found
-    # Future improvement: Add parameter validation and return 400 Bad Request
-
+  test "description_receiver should reject missing image_core_id" do
     post description_receiver_image_cores_url, params: {
       data: {
         description: "Test description"
@@ -602,16 +662,11 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
       }
     }, as: :json
 
-    # Rails catches RecordNotFound and returns 404
-    assert_response :not_found
+    assert_response :unauthorized
   end
 
-  test "description_receiver should handle invalid image_core_id" do
+  test "description_receiver should reject invalid image_core_id" do
     invalid_id = 999999
-
-    # Current behavior: find(999999) raises RecordNotFound
-    # Rails rescues and returns 404 Not Found
-    # This is actually correct behavior
 
     post description_receiver_image_cores_url, params: {
       data: {
@@ -620,8 +675,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
       }
     }, as: :json
 
-    # Rails catches RecordNotFound and returns 404
-    assert_response :not_found
+    assert_response :unauthorized
   end
 
   # PHASE 3: status_receiver success cases
@@ -630,11 +684,14 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
     image_core = image_cores(:one)
     original_status = image_core.status
     new_status = 2  # processing
+    attempt = local_attempt_for(image_core)
 
     post status_receiver_image_cores_url, params: {
       data: {
         image_core_id: image_core.id,
-        status: new_status
+        status: new_status,
+        attempt_id: attempt.id,
+        callback_token: attempt.callback_token
       }
     }, as: :json
 
@@ -645,31 +702,37 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
   test "status_receiver should broadcast to image_status_channel" do
     image_core = image_cores(:one)
-    new_status = 3  # done
+    new_status = 2  # processing
+    attempt = local_attempt_for(image_core)
 
     assert_broadcasts "image_status_channel", 1 do
       post status_receiver_image_cores_url, params: {
         data: {
           image_core_id: image_core.id,
-          status: new_status
+          status: new_status,
+          attempt_id: attempt.id,
+          callback_token: attempt.callback_token
         }
       }, as: :json
     end
 
     # Verify status was updated in database
     image_core.reload
-    assert_equal "done", image_core.status
+    assert_equal "processing", image_core.status
   end
 
   test "status_receiver should skip CSRF token verification" do
     image_core = image_cores(:one)
+    attempt = local_attempt_for(image_core)
 
     # Post without CSRF token (would normally fail)
     assert_nothing_raised do
       post status_receiver_image_cores_url, params: {
         data: {
           image_core_id: image_core.id,
-          status: 2  # processing
+          status: 2,  # processing
+          attempt_id: attempt.id,
+          callback_token: attempt.callback_token
         }
       }, as: :json
     end
@@ -681,12 +744,7 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
   # PHASE 4: status_receiver error cases
 
-  test "status_receiver should handle missing image_core_id" do
-    # Current behavior: params[:data][:image_core_id] is nil
-    # .to_i on nil returns 0, then find(0) raises RecordNotFound
-    # Rails rescues and returns 404 Not Found
-    # Future improvement: Add parameter validation and return 400 Bad Request
-
+  test "status_receiver should reject missing image_core_id" do
     post status_receiver_image_cores_url, params: {
       data: {
         status: 2
@@ -694,16 +752,11 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
       }
     }, as: :json
 
-    # Rails catches RecordNotFound and returns 404
-    assert_response :not_found
+    assert_response :unauthorized
   end
 
-  test "status_receiver should handle invalid image_core_id" do
+  test "status_receiver should reject invalid image_core_id" do
     invalid_id = 999999
-
-    # Current behavior: find(999999) raises RecordNotFound
-    # Rails rescues and returns 404 Not Found
-    # This is actually correct behavior
 
     post status_receiver_image_cores_url, params: {
       data: {
@@ -712,11 +765,72 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
       }
     }, as: :json
 
-    # Rails catches RecordNotFound and returns 404
-    assert_response :not_found
+    assert_response :unauthorized
+  end
+
+  test "description_receiver rejects missing callback token without mutating image" do
+    image_core = image_cores(:one)
+    original_description = image_core.description
+    local_attempt_for(image_core)
+
+    post description_receiver_image_cores_url, params: {
+      data: {
+        image_core_id: image_core.id,
+        description: "unauthenticated description"
+      }
+    }, as: :json
+
+    assert_response :unauthorized
+    assert_equal original_description, image_core.reload.description
+  end
+
+  test "description_receiver ignores canceled attempt callback" do
+    image_core = image_cores(:one)
+    original_description = image_core.description
+    attempt = local_attempt_for(image_core)
+    token = attempt.callback_token
+    attempt.cancel!
+
+    post description_receiver_image_cores_url, params: {
+      data: {
+        image_core_id: image_core.id,
+        description: "stale local description",
+        attempt_id: attempt.id,
+        callback_token: token
+      }
+    }, as: :json
+
+    assert_response :success
+    assert_equal original_description, image_core.reload.description
+  end
+
+  test "status_receiver rejects callback token for another image" do
+    image_core = image_cores(:one)
+    other_image = image_cores(:two)
+    attempt = local_attempt_for(image_core)
+
+    post status_receiver_image_cores_url, params: {
+      data: {
+        image_core_id: other_image.id,
+        status: 2,
+        attempt_id: attempt.id,
+        callback_token: attempt.callback_token
+      }
+    }, as: :json
+
+    assert_response :unauthorized
+    assert_equal "in_queue", image_core.reload.status
+    assert_not_equal "processing", other_image.reload.status
   end
 
   private
+
+    def local_attempt_for(image_core)
+      image_core.image_description_generation_attempts.active.each(&:cancel!)
+      attempt = image_core.start_description_generation_attempt!(provider: "local")
+      image_core.update!(status: :in_queue)
+      attempt
+    end
 
     def with_env(values)
       old_values = values.keys.to_h { |key| [ key, ENV[key] ] }

--- a/meme_search/meme_search_app/test/jobs/generate_image_description_job_test.rb
+++ b/meme_search/meme_search_app/test/jobs/generate_image_description_job_test.rb
@@ -6,21 +6,31 @@ class GenerateImageDescriptionJobTest < ActiveJob::TestCase
   test "generates description for an existing image" do
     image_core = image_cores(:one)
     image_core.update!(status: :in_queue)
-    provider = Minitest::Mock.new
-    provider.expect(:generate, ImageDescriptionProviders::Result.new(success: true, message: "Generated description.", queued: false), [ image_core ])
-
-    ImageDescriptionProviders::Factory.stub(:build, ->(_configuration) { provider }) do
-      GenerateImageDescriptionJob.perform_now(image_core.id)
+    attempt = image_core.start_description_generation_attempt!(provider: "openai")
+    generated_with = nil
+    provider = Object.new
+    provider.define_singleton_method(:generate) do |received_image_core, attempt:|
+      generated_with = [ received_image_core, attempt ]
+      ImageDescriptionProviders::Result.new(success: true, message: "Generated description.", queued: false)
     end
 
-    assert_mock provider
+    ImageDescriptionProviders::Factory.stub(:build, ->(_configuration) { provider }) do
+      GenerateImageDescriptionJob.perform_now(image_core.id, nil, attempt.id)
+    end
+
+    assert_equal [ image_core, attempt ], generated_with
   end
 
   test "uses provider settings pinned when the job was enqueued" do
     image_core = image_cores(:one)
     image_core.update!(status: :in_queue)
-    provider = Minitest::Mock.new
-    provider.expect(:generate, ImageDescriptionProviders::Result.new(success: true, message: "Generated description.", queued: false), [ image_core ])
+    attempt = image_core.start_description_generation_attempt!(provider: "openai")
+    generated_attempt = nil
+    provider = Object.new
+    provider.define_singleton_method(:generate) do |_received_image_core, attempt:|
+      generated_attempt = attempt
+      ImageDescriptionProviders::Result.new(success: true, message: "Generated description.", queued: false)
+    end
     provider_options = {
       "provider" => "openai",
       "openai_base_url" => "http://queued.example/v1",
@@ -33,10 +43,10 @@ class GenerateImageDescriptionJobTest < ActiveJob::TestCase
       assert_equal "gpt-queued", configuration.openai_model
       provider
     }) do
-      GenerateImageDescriptionJob.perform_now(image_core.id, provider_options)
+      GenerateImageDescriptionJob.perform_now(image_core.id, provider_options, attempt.id)
     end
 
-    assert_mock provider
+    assert_equal attempt, generated_attempt
   end
 
   test "does nothing when image no longer exists" do
@@ -50,10 +60,37 @@ class GenerateImageDescriptionJobTest < ActiveJob::TestCase
   test "does nothing when image is no longer queued" do
     image_core = image_cores(:one)
     image_core.update!(status: :not_started)
+    attempt = image_core.start_description_generation_attempt!(provider: "openai")
 
     ImageDescriptionProviders::Factory.stub(:build, -> { flunk "provider should not be built for unqueued image" }) do
       assert_nothing_raised do
-        GenerateImageDescriptionJob.perform_now(image_core.id)
+        GenerateImageDescriptionJob.perform_now(image_core.id, nil, attempt.id)
+      end
+    end
+  end
+
+  test "does nothing when attempt was canceled" do
+    image_core = image_cores(:one)
+    image_core.update!(status: :in_queue)
+    attempt = image_core.start_description_generation_attempt!(provider: "openai")
+    attempt.cancel!
+
+    ImageDescriptionProviders::Factory.stub(:build, -> { flunk "provider should not be built for canceled attempt" }) do
+      assert_nothing_raised do
+        GenerateImageDescriptionJob.perform_now(image_core.id, nil, attempt.id)
+      end
+    end
+  end
+
+  test "does nothing when attempt belongs to another image" do
+    image_core = image_cores(:one)
+    other_image = image_cores(:two)
+    image_core.update!(status: :in_queue)
+    attempt = other_image.start_description_generation_attempt!(provider: "openai")
+
+    ImageDescriptionProviders::Factory.stub(:build, -> { flunk "provider should not be built for mismatched attempt" }) do
+      assert_nothing_raised do
+        GenerateImageDescriptionJob.perform_now(image_core.id, nil, attempt.id)
       end
     end
   end

--- a/meme_search/meme_search_app/test/models/image_description_bulk_operation_test.rb
+++ b/meme_search/meme_search_app/test/models/image_description_bulk_operation_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ImageDescriptionBulkOperationTest < ActiveSupport::TestCase
+  test "status snapshot counts only attempts attached to operation" do
+    operation = ImageDescriptionBulkOperation.create!(
+      provider: "local",
+      provider_queued: true,
+      total_count: 2,
+      started_at: Time.current
+    )
+    included = image_cores(:one)
+    included.update!(status: :in_queue)
+    included.start_description_generation_attempt!(provider: "local", bulk_operation: operation)
+
+    outside = image_cores(:two)
+    outside.update!(status: :done)
+    outside.start_description_generation_attempt!(provider: "local")
+
+    snapshot = operation.status_snapshot
+
+    assert_equal 2, snapshot[:total]
+    assert_equal 1, snapshot[:status_counts][:in_queue]
+    assert_equal 0, snapshot[:status_counts][:done]
+    assert_equal false, snapshot[:is_complete]
+  end
+
+  test "completed operation is removed from current active operation" do
+    operation = ImageDescriptionBulkOperation.create!(
+      provider: "openai",
+      provider_queued: false,
+      total_count: 0,
+      started_at: Time.current
+    )
+
+    snapshot = operation.mark_completed_if_finished!
+
+    assert_equal true, snapshot[:is_complete]
+    assert_equal "completed", operation.reload.status
+    assert_nil ImageDescriptionBulkOperation.current
+  end
+end

--- a/meme_search/meme_search_app/test/models/image_description_generation_attempt_test.rb
+++ b/meme_search/meme_search_app/test/models/image_description_generation_attempt_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ImageDescriptionGenerationAttemptTest < ActiveSupport::TestCase
+  test "image can have only one active attempt" do
+    image_core = image_cores(:one)
+    image_core.start_description_generation_attempt!(provider: "openai")
+
+    assert_raises ActiveRecord::RecordInvalid do
+      image_core.start_description_generation_attempt!(provider: "openai")
+    end
+  end
+
+  test "canceled attempt is no longer active and cannot save description" do
+    image_core = image_cores(:one)
+    attempt = image_core.start_description_generation_attempt!(provider: "openai")
+    image_core.update!(status: :in_queue)
+    attempt.cancel!
+
+    assert_not attempt.reload.active_for_image?
+    assert_not attempt.succeed_with_description!("stale description")
+    assert_not_equal "stale description", image_core.reload.description
+    assert_equal "not_started", image_core.status
+  end
+
+  test "active attempt can transition and save description" do
+    image_core = image_cores(:one)
+    attempt = image_core.start_description_generation_attempt!(provider: "openai")
+    image_core.update!(status: :in_queue)
+
+    assert attempt.transition_to_processing!
+    assert_equal "processing", attempt.status
+    assert_equal "processing", image_core.reload.status
+
+    assert attempt.succeed_with_description!("fresh description")
+    assert_equal "succeeded", attempt.status
+    assert_equal "fresh description", image_core.reload.description
+    assert_equal "done", image_core.status
+  end
+
+  test "cancel active attempt resets queued image to not started" do
+    image_core = image_cores(:one)
+    image_core.start_description_generation_attempt!(provider: "openai")
+    image_core.update!(status: :in_queue)
+
+    assert image_core.cancel_active_description_generation_attempt!
+    assert_equal "not_started", image_core.reload.status
+    assert_equal "canceled", image_core.image_description_generation_attempts.last.status
+  end
+
+  test "callback token verifies only matching attempt and image" do
+    image_core = image_cores(:one)
+    attempt = image_core.start_description_generation_attempt!(provider: "local")
+    token = attempt.callback_token
+
+    assert_equal attempt, ImageDescriptionGenerationAttempt.find_verified_callback_attempt(
+      attempt_id: attempt.id,
+      image_core_id: image_core.id,
+      callback_token: token
+    )
+
+    assert_nil ImageDescriptionGenerationAttempt.find_verified_callback_attempt(
+      attempt_id: attempt.id,
+      image_core_id: image_cores(:two).id,
+      callback_token: token
+    )
+    assert_nil ImageDescriptionGenerationAttempt.find_verified_callback_attempt(
+      attempt_id: attempt.id,
+      image_core_id: image_core.id,
+      callback_token: "bad-token"
+    )
+  end
+end

--- a/meme_search/meme_search_app/test/services/image_description_providers/factory_test.rb
+++ b/meme_search/meme_search_app/test/services/image_description_providers/factory_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ImageDescriptionProviders::FactoryTest < ActiveSupport::TestCase
+  test "builds local provider for local configuration" do
+    configuration = ImageDescriptionProviders::Configuration.from_job_options({ "provider" => "local" })
+
+    assert_instance_of ImageDescriptionProviders::LocalProvider, ImageDescriptionProviders::Factory.build(configuration)
+  end
+
+  test "builds openai provider for openai configuration" do
+    configuration = ImageDescriptionProviders::Configuration.from_job_options({
+      "provider" => "openai",
+      "openai_base_url" => "http://openai.test/v1",
+      "openai_model" => "vision-test"
+    })
+
+    assert_instance_of ImageDescriptionProviders::OpenaiProvider, ImageDescriptionProviders::Factory.build(configuration)
+  end
+
+  test "unknown provider fails closed" do
+    configuration = ImageDescriptionProviders::Configuration.from_job_options({ "provider" => "surprise" })
+
+    assert_raises ArgumentError do
+      ImageDescriptionProviders::Factory.build(configuration)
+    end
+  end
+end

--- a/meme_search/meme_search_app/test/services/image_description_providers/local_provider_test.rb
+++ b/meme_search/meme_search_app/test/services/image_description_providers/local_provider_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "json"
+
+class ImageDescriptionProviders::LocalProviderTest < ActiveSupport::TestCase
+  def setup
+    @image_core = image_cores(:one)
+    @image_core.update!(status: :not_started)
+    ImageToText.create!(
+      name: "Test Model",
+      resource: "org/test",
+      description: "Test",
+      current: true
+    )
+  end
+
+  test "queues local job with signed attempt callback token" do
+    stub_request(:post, "http://image_to_text_generator:8000/add_job")
+      .to_return(status: 200, body: '{"status":"queued"}', headers: { "Content-Type" => "application/json" })
+
+    result = ImageDescriptionProviders::LocalProvider.new.generate(@image_core)
+
+    assert result.success?
+    assert_equal "in_queue", @image_core.reload.status
+    attempt = @image_core.active_description_generation_attempt
+    assert_equal "local", attempt.provider
+
+    payload = nil
+    assert_requested(:post, "http://image_to_text_generator:8000/add_job") do |request|
+      payload = JSON.parse(request.body)
+    end
+
+    assert_equal @image_core.id, payload.fetch("image_core_id")
+    assert_equal attempt.id, payload.fetch("attempt_id")
+    assert_equal attempt, ImageDescriptionGenerationAttempt.find_verified_callback_attempt(
+      attempt_id: payload.fetch("attempt_id"),
+      image_core_id: payload.fetch("image_core_id"),
+      callback_token: payload.fetch("callback_token")
+    )
+  end
+
+  test "failed local queue request fails active attempt" do
+    stub_request(:post, "http://image_to_text_generator:8000/add_job")
+      .to_return(status: 503, body: '{"error":"offline"}', headers: { "Content-Type" => "application/json" })
+
+    result = ImageDescriptionProviders::LocalProvider.new.generate(@image_core)
+
+    assert_not result.success?
+    assert_equal "failed", @image_core.reload.status
+    attempt = @image_core.image_description_generation_attempts.last
+    assert_equal "failed", attempt.status
+    assert_match "503", attempt.error_message
+  end
+end

--- a/meme_search/meme_search_app/test/services/image_description_providers/openai_provider_test.rb
+++ b/meme_search/meme_search_app/test/services/image_description_providers/openai_provider_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+
+class ImageDescriptionProviders::OpenaiProviderTest < ActiveSupport::TestCase
+  def setup
+    @image_dir = Rails.root.join("public", "memes", "openai_attempt_path")
+    FileUtils.mkdir_p(@image_dir)
+    @image_path = ImagePath.create!(name: "openai_attempt_path")
+    @image_core = ImageCore.create!(name: "attempt.jpg", image_path: @image_path)
+    File.binwrite(@image_dir.join(@image_core.name), "fake image bytes")
+  end
+
+  def teardown
+    FileUtils.rm_rf(@image_dir) if @image_dir
+    WebMock.reset!
+  end
+
+  test "does not save when attempt was canceled before provider runs" do
+    attempt = @image_core.start_description_generation_attempt!(provider: "openai")
+    @image_core.update!(status: :in_queue)
+    attempt.cancel!
+
+    with_openai_env do
+      result = ImageDescriptionProviders::OpenaiProvider.new.generate(@image_core, attempt: attempt)
+
+      assert_not result.success?
+      assert_not_requested :post, "http://openai.test/v1/chat/completions"
+    end
+
+    assert_nil @image_core.reload.description
+    assert_equal "canceled", attempt.reload.status
+  end
+
+  test "saves only through active attempt" do
+    description = "A fresh active attempt description."
+    attempt = @image_core.start_description_generation_attempt!(provider: "openai")
+    @image_core.update!(status: :in_queue)
+
+    with_openai_env do
+      stub_request(:post, "http://openai.test/v1/chat/completions")
+        .to_return(
+          status: 200,
+          body: { choices: [ { message: { content: description } } ] }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      @image_core.stub(:refresh_description_embeddings, true) do
+        ActionCable.server.stub(:broadcast, true) do
+          result = ImageDescriptionProviders::OpenaiProvider.new.generate(@image_core, attempt: attempt)
+
+          assert result.success?
+        end
+      end
+    end
+
+    assert_equal description, @image_core.reload.description
+    assert_equal "done", @image_core.status
+    assert_equal "succeeded", attempt.reload.status
+  end
+
+  private
+
+    def with_openai_env
+      old_values = {
+        "IMAGE_DESCRIPTION_PROVIDER" => ENV["IMAGE_DESCRIPTION_PROVIDER"],
+        "OPENAI_API_BASE_URL" => ENV["OPENAI_API_BASE_URL"],
+        "OPENAI_API_KEY" => ENV["OPENAI_API_KEY"],
+        "OPENAI_VISION_MODEL" => ENV["OPENAI_VISION_MODEL"]
+      }
+      ENV["IMAGE_DESCRIPTION_PROVIDER"] = "openai"
+      ENV["OPENAI_API_BASE_URL"] = "http://openai.test/v1"
+      ENV["OPENAI_API_KEY"] = "test-key"
+      ENV["OPENAI_VISION_MODEL"] = "vision-test"
+      yield
+    ensure
+      old_values.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    end
+end

--- a/playwright-docker/utils/python-service-client.ts
+++ b/playwright-docker/utils/python-service-client.ts
@@ -8,17 +8,15 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
 
 export interface AddJobRequest {
-  image_id: string;
+  image_core_id: number;
   image_path: string;
-  model_id: string;
-  webhook_url_description?: string;
-  webhook_url_status?: string;
+  model: string;
+  attempt_id: number;
+  callback_token: string;
 }
 
 export interface AddJobResponse {
-  message: string;
-  job_id: number;
-  image_id: number;
+  status: string;
 }
 
 export interface QueueStatusResponse {
@@ -28,10 +26,11 @@ export interface QueueStatusResponse {
 
 export interface JobInfo {
   id: number;
-  image_id: number;
+  image_core_id: number;
   image_path: string;
-  model_id: string;
-  status: string;
+  model: string;
+  attempt_id: number;
+  callback_token: string;
   created_at: string;
   updated_at: string;
 }

--- a/playwright-docker/utils/workflow-helpers.ts
+++ b/playwright-docker/utils/workflow-helpers.ts
@@ -103,6 +103,11 @@ export async function triggerDescriptionGeneration(imageId: number): Promise<voi
 
     # Construct full file path
     full_path = File.join(image_path.name, image.name)
+    attempt = image.start_description_generation_attempt!(
+      provider: 'local',
+      provider_settings: { model: (model&.name || 'test') }
+    )
+    image.update!(status: :in_queue)
 
     uri = URI('http://python-service:8000/add_job')
     http = Net::HTTP.new(uri.host, uri.port)
@@ -111,7 +116,9 @@ export async function triggerDescriptionGeneration(imageId: number): Promise<voi
     params = {
       'image_core_id' => image.id,
       'image_path' => full_path,
-      'model' => (model&.name || 'test')
+      'model' => (model&.name || 'test'),
+      'attempt_id' => attempt.id,
+      'callback_token' => attempt.callback_token
     }
     request.body = params.to_json
 


### PR DESCRIPTION
## Summary
- add durable image description generation attempts and bulk operations
- bind local/OpenAI generation, callbacks, cancel, and bulk progress to active attempts
- require signed attempt callback metadata through the Python queue and smoke helpers

## Verification
- git diff --check
- Rails focused suite: 95 runs, 279 assertions, 0 failures, 0 errors
- Rails full suite: 259 runs, 842 assertions, 0 failures, 0 errors, 4 skips
- Python pytest: 120 passed, 15 warnings

Stacked on top of #153 / feat: add OpenAI-compatible vision descriptions.