### PR TITLE
test: add provider settings and OpenAI generation coverage

### DIFF
--- a/meme_search/meme_search_app/lib/tasks/test_db.rake
+++ b/meme_search/meme_search_app/lib/tasks/test_db.rake
@@ -27,7 +27,19 @@ namespace :db do
       puts "Cleaning test database..."
       # Use delete_all to avoid callbacks and foreign key issues
       # Delete in reverse dependency order
-      ActiveRecord::Base.connection.execute("TRUNCATE TABLE image_tags, image_embeddings, image_cores, tag_names, image_paths, image_to_texts RESTART IDENTITY CASCADE")
+      ActiveRecord::Base.connection.execute(
+        "TRUNCATE TABLE " \
+          "image_tags, " \
+          "image_embeddings, " \
+          "image_description_generation_attempts, " \
+          "image_description_bulk_operations, " \
+          "image_cores, " \
+          "tag_names, " \
+          "image_paths, " \
+          "image_to_texts, " \
+          "description_provider_settings " \
+          "RESTART IDENTITY CASCADE"
+      )
 
       puts "Test database cleaned!"
     end

--- a/meme_search/meme_search_app/test/integration/openai_description_generation_test.rb
+++ b/meme_search/meme_search_app/test/integration/openai_description_generation_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+
+class OpenaiDescriptionGenerationTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  def setup
+    reset_provider_setting
+    @image_dir = Rails.root.join("public", "memes", "openai_integration_path")
+    FileUtils.mkdir_p(@image_dir)
+    @image_path = ImagePath.create!(name: "openai_integration_path")
+    @image_core = ImageCore.create!(name: "integration.jpg", image_path: @image_path, status: :not_started)
+    File.binwrite(@image_dir.join(@image_core.name), "fake image bytes")
+  end
+
+  def teardown
+    FileUtils.rm_rf(@image_dir) if @image_dir
+    reset_provider_setting
+    WebMock.reset!
+  end
+
+  test "saved OpenAI-compatible settings generate a description through the queued job without real network" do
+    api_key = "sk-integration-openai-1234"
+    generated_description = "A mocked cloud vision description."
+    captured_request_body = nil
+
+    with_clean_openai_env do
+      post save_openai_settings_settings_image_to_texts_path, params: {
+        description_provider_setting: {
+          openai_base_url: "http://openai.test/v1",
+          openai_model: "gpt-4.1",
+          openai_api_key: api_key
+        }
+      }
+      assert_redirected_to settings_image_to_texts_path(provider_tab: "openai")
+
+      stub = stub_request(:post, "http://openai.test/v1/chat/completions")
+        .with(headers: { "Authorization" => "Bearer #{api_key}" }) do |request|
+          captured_request_body = JSON.parse(request.body)
+          true
+        end
+        .to_return(
+          status: 200,
+          body: { choices: [ { message: { content: generated_description } } ] }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      assert_difference -> { ImageDescriptionGenerationAttempt.count }, 1 do
+        assert_enqueued_jobs 1, only: GenerateImageDescriptionJob do
+          post generate_description_image_core_path(@image_core)
+        end
+      end
+
+      assert_response :redirect
+      attempt = @image_core.reload.active_description_generation_attempt
+      assert_equal "queued", attempt.status
+      assert_equal "openai", attempt.provider
+      assert_equal(
+        {
+          "provider" => "openai",
+          "openai_base_url" => "http://openai.test/v1",
+          "openai_model" => "gpt-4.1"
+        },
+        attempt.provider_settings
+      )
+      refute_includes enqueued_jobs.last.to_s, api_key
+
+      perform_enqueued_jobs
+
+      assert_requested stub, times: 1
+      assert_equal "gpt-4.1", captured_request_body.fetch("model")
+      image_content = captured_request_body.dig("messages", 0, "content").find { |part| part["type"] == "image_url" }
+      assert_match %r{\Adata:image/jpeg;base64,}, image_content.dig("image_url", "url")
+    end
+
+    @image_core.reload
+    assert_equal generated_description, @image_core.description
+    assert_equal "done", @image_core.status
+
+    attempt = @image_core.image_description_generation_attempts.order(:created_at).last
+    assert_equal "succeeded", attempt.status
+    refute_includes attempt.provider_settings.to_s, api_key
+    assert_not_requested :post, "https://api.openai.com/v1/chat/completions"
+  end
+
+  private
+
+    def with_clean_openai_env
+      keys = %w[
+        IMAGE_DESCRIPTION_PROVIDER
+        OPENAI_API_BASE_URL
+        OPENAI_API_KEY
+        OPENAI_VISION_MODEL
+      ]
+      old_values = keys.index_with { |key| ENV[key] }
+      keys.each { |key| ENV.delete(key) }
+      yield
+    ensure
+      old_values.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    end
+
+    def reset_provider_setting
+      DescriptionProviderSetting.delete_all
+    end
+end

--- a/meme_search/meme_search_app/test/test_helper.rb
+++ b/meme_search/meme_search_app/test/test_helper.rb
@@ -18,6 +18,7 @@ end
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "minitest/mock"
 require "webmock/minitest"
 
 # Allow real HTTP connections in tests (only stub specific requests)
@@ -37,6 +38,7 @@ module ActiveSupport
     # Clear enqueued jobs before each test
     setup do
       clear_enqueued_jobs if respond_to?(:clear_enqueued_jobs)
+      DescriptionProviderSetting.delete_all if defined?(DescriptionProviderSetting)
     end
 
     # Add more helper methods to be used by all tests here...

--- a/playwright/pages/settings/image-to-texts.page.ts
+++ b/playwright/pages/settings/image-to-texts.page.ts
@@ -3,77 +3,110 @@ import type { Page, Locator } from '@playwright/test';
 export class ImageToTextsPage {
   readonly page: Page;
   readonly heading: Locator;
+  readonly localTab: Locator;
+  readonly openAiTab: Locator;
+  readonly saveLocalButton: Locator;
+  readonly saveCloudButton: Locator;
+  readonly clearSavedKeyButton: Locator;
+  readonly baseUrlInput: Locator;
+  readonly cloudModelSelect: Locator;
+  readonly apiKeyInput: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.heading = page.locator('h1');
+    this.localTab = page.getByRole('button', { name: 'Local generator' });
+    this.openAiTab = page.getByRole('button', { name: 'OpenAI-compatible API' });
+    this.saveLocalButton = page.getByRole('button', { name: 'Save Local Selection' });
+    this.saveCloudButton = page.getByRole('button', { name: 'Save Cloud Selection' });
+    this.clearSavedKeyButton = page.getByRole('button', { name: 'Clear saved key' });
+    this.baseUrlInput = page.getByLabel('Base URL');
+    this.cloudModelSelect = page.getByLabel('Cloud model');
+    this.apiKeyInput = page.getByLabel('API key');
   }
 
-  /**
-   * Navigate to the image-to-texts settings page
-   */
-  async goto(): Promise<void> {
-    await this.page.goto('/settings/image_to_texts');
+  async goto(providerTab: 'local' | 'openai' = 'local'): Promise<void> {
+    await this.page.goto(`/settings/image_to_texts?provider_tab=${providerTab}`);
     await this.page.waitForLoadState('networkidle');
   }
 
-  /**
-   * Get the page heading text
-   */
   async getHeading(): Promise<string> {
     return (await this.heading.textContent()) || '';
   }
 
-  /**
-   * Get a model checkbox input by ID
-   */
-  getModelCheckbox(modelId: number): Locator {
-    return this.page.locator(`input[id='${modelId}']`);
+  getModelRadio(modelId: number): Locator {
+    return this.page.locator(`#image_to_text_${modelId}`);
   }
 
-  /**
-   * Get a model label by ID
-   */
   getModelLabel(modelId: number): Locator {
-    return this.page.locator(`label[for='${modelId}']`);
+    return this.page.locator(`label[for='image_to_text_${modelId}']`);
   }
 
-  /**
-   * Check if a model is selected
-   */
   async isModelSelected(modelId: number): Promise<boolean> {
-    const checkbox = this.getModelCheckbox(modelId);
-    return await checkbox.isChecked();
+    return await this.getModelRadio(modelId).isChecked();
   }
 
-  /**
-   * Select a model by clicking its label
-   */
   async selectModel(modelId: number): Promise<void> {
-    const label = this.getModelLabel(modelId);
-    await label.click();
-    // Wait for the state to update (toggle switches can have animations/transitions)
-    await this.page.waitForTimeout(500);
+    await this.getModelLabel(modelId).click();
   }
 
-  /**
-   * Get all model checkboxes
-   */
-  async getAllModelCheckboxes(): Promise<Locator[]> {
-    const checkboxes = await this.page.locator('input[type="checkbox"]').all();
-    return checkboxes;
+  async saveLocalSelection(): Promise<void> {
+    await Promise.all([
+      this.page.waitForURL(/\/settings\/image_to_texts\?provider_tab=local/),
+      this.saveLocalButton.click(),
+    ]);
+    await this.page.waitForLoadState('networkidle');
   }
 
-  /**
-   * Get the count of model checkboxes
-   */
   async getModelCount(): Promise<number> {
-    return await this.page.locator('input[type="checkbox"]').count();
+    return await this.page.locator('input[name="current_id"]').count();
   }
 
-  /**
-   * Verify that only one model is selected
-   */
+  async openLocalTab(): Promise<void> {
+    await Promise.all([
+      this.page.waitForURL(/\/settings\/image_to_texts\?provider_tab=local/),
+      this.localTab.click(),
+    ]);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async openCloudTab(): Promise<void> {
+    await Promise.all([
+      this.page.waitForURL(/\/settings\/image_to_texts\?provider_tab=openai/),
+      this.openAiTab.click(),
+    ]);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async saveCloudSettings(options: { baseUrl: string; model: string; apiKey?: string }): Promise<void> {
+    await this.baseUrlInput.fill(options.baseUrl);
+    await this.cloudModelSelect.selectOption(options.model);
+
+    if (options.apiKey !== undefined) {
+      await this.apiKeyInput.fill(options.apiKey);
+    }
+
+    await Promise.all([
+      this.page.waitForURL(/\/settings\/image_to_texts\?provider_tab=openai/),
+      this.saveCloudButton.click(),
+    ]);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async clearSavedKey(): Promise<void> {
+    await Promise.all([
+      this.page.waitForURL(/\/settings\/image_to_texts\?provider_tab=openai/),
+      this.clearSavedKeyButton.click(),
+    ]);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async cloudModelOptions(): Promise<string[]> {
+    return await this.cloudModelSelect.locator('option').evaluateAll((options) =>
+      options.map((option) => (option as HTMLOptionElement).value),
+    );
+  }
+
   async verifyOnlyOneModelSelected(selectedId: number, allIds: number[]): Promise<void> {
     for (const id of allIds) {
       const isChecked = await this.isModelSelected(id);

--- a/playwright/tests/image-to-texts.spec.ts
+++ b/playwright/tests/image-to-texts.spec.ts
@@ -2,54 +2,36 @@ import { test, expect } from '@playwright/test';
 import { ImageToTextsPage } from '../pages/settings/image-to-texts.page';
 import { resetTestDatabase } from '../utils/db-setup';
 
-/**
- * Image-to-Texts Settings Tests
- *
- * These tests verify the model selection UI in the settings page.
- * Migrated from: test/system/image_to_texts_test.rb
- */
-
 test.describe('Image-to-Texts Settings', () => {
   let imageToTextsPage: ImageToTextsPage;
 
-  // Reset and seed database before each test
   test.beforeEach(async ({ page }) => {
-    // Reset test database with fixture data
     await resetTestDatabase();
-
-    // Initialize page object
     imageToTextsPage = new ImageToTextsPage(page);
   });
 
-  test('visiting the index page shows available models heading', async ({ page }) => {
-    // Navigate to the settings page
+  test('visiting the index page shows available models heading', async () => {
     await imageToTextsPage.goto();
 
-    // Verify the heading is correct
     const headingText = await imageToTextsPage.getHeading();
     expect(headingText).toContain('AI Models');
   });
 
-  test('updating the current model to all available models', async ({ page }) => {
-    // Test data: All 5 model IDs from seed (Florence-2-base is default with ID 1)
+  test('updating the current local model to all available models', async () => {
     const modelIds = [2, 3, 4, 5, 1]; // Start from 2 since 1 is already selected
 
     await imageToTextsPage.goto();
 
-    // Model 1 (Florence-2-base) should be selected by default
     const defaultSelected = await imageToTextsPage.isModelSelected(1);
     expect(defaultSelected).toBe(true);
 
-    // Test switching to each model (stay on same page, no refresh)
     for (const modelId of modelIds) {
-      // Select the model by clicking its label
       await imageToTextsPage.selectModel(modelId);
+      await imageToTextsPage.saveLocalSelection();
 
-      // Assert the model is now selected
       const nowSelected = await imageToTextsPage.isModelSelected(modelId);
       expect(nowSelected).toBe(true);
 
-      // Assert all other models are not selected
       const allIds = [1, 2, 3, 4, 5];
       for (const otherId of allIds) {
         if (otherId !== modelId) {
@@ -60,28 +42,75 @@ test.describe('Image-to-Texts Settings', () => {
     }
   });
 
-  test('only one model can be selected at a time', async ({ page }) => {
+  test('only one local model can be selected at a time', async () => {
     await imageToTextsPage.goto();
 
-    // Model 1 (Florence-2-base) should be selected by default
     expect(await imageToTextsPage.isModelSelected(1)).toBe(true);
     expect(await imageToTextsPage.isModelSelected(2)).toBe(false);
 
-    // Select model 2 (Florence-2-large)
     await imageToTextsPage.selectModel(2);
     expect(await imageToTextsPage.isModelSelected(1)).toBe(false);
     expect(await imageToTextsPage.isModelSelected(2)).toBe(true);
 
-    // Select model 3 (SmolVLM-256M)
     await imageToTextsPage.selectModel(3);
     expect(await imageToTextsPage.isModelSelected(1)).toBe(false);
     expect(await imageToTextsPage.isModelSelected(2)).toBe(false);
     expect(await imageToTextsPage.isModelSelected(3)).toBe(true);
 
-    // Select back to model 1
     await imageToTextsPage.selectModel(1);
     expect(await imageToTextsPage.isModelSelected(1)).toBe(true);
     expect(await imageToTextsPage.isModelSelected(2)).toBe(false);
     expect(await imageToTextsPage.isModelSelected(3)).toBe(false);
+  });
+
+  test('switching between local and OpenAI-compatible provider settings', async ({ page }) => {
+    const fakeKey = 'sk-playwright-provider-1234';
+
+    await imageToTextsPage.goto();
+    await expect(page.getByRole('heading', { name: 'Local model' })).toBeVisible();
+    await expect(page.getByText('Choose one local model. This is the default path for Meme Search.')).toBeVisible();
+    await expect(imageToTextsPage.saveLocalButton).toBeVisible();
+
+    await imageToTextsPage.openCloudTab();
+    await expect(page.getByRole('heading', { name: 'OpenAI-compatible provider' })).toBeVisible();
+    await expect(imageToTextsPage.apiKeyInput).toHaveValue('');
+    await expect(imageToTextsPage.saveCloudButton).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Test connection' })).toBeVisible();
+    await expect(imageToTextsPage.clearSavedKeyButton).toBeVisible();
+
+    await expect(await imageToTextsPage.cloudModelOptions()).toEqual([
+      'gpt-4o-mini',
+      'gpt-4.1-mini',
+      'gpt-4.1',
+    ]);
+
+    await imageToTextsPage.saveCloudSettings({
+      baseUrl: 'http://openai.test/v1',
+      model: 'gpt-4.1-mini',
+      apiKey: fakeKey,
+    });
+
+    await expect(page.getByText('OpenAI-compatible provider settings saved.')).toBeVisible();
+    await expect(page.getByText('sk-...1234')).toBeVisible();
+    await expect(page.getByText(fakeKey)).toHaveCount(0);
+    await expect(page.getByText('Not tested')).toBeVisible();
+    await expect(imageToTextsPage.baseUrlInput).toHaveValue('http://openai.test/v1');
+    await expect(imageToTextsPage.cloudModelSelect).toHaveValue('gpt-4.1-mini');
+    await expect(imageToTextsPage.apiKeyInput).toHaveValue('');
+
+    await imageToTextsPage.clearSavedKey();
+    await expect(page.getByText('Saved OpenAI API key cleared.')).toBeVisible();
+    await expect(page.getByText('Not saved')).toBeVisible();
+    await expect(page.getByText('sk-...1234')).toHaveCount(0);
+
+    await imageToTextsPage.openLocalTab();
+    await imageToTextsPage.selectModel(2);
+    await imageToTextsPage.saveLocalSelection();
+    await expect(page.getByText('Current model set to:')).toBeVisible();
+    expect(await imageToTextsPage.isModelSelected(2)).toBe(true);
+
+    await imageToTextsPage.openCloudTab();
+    await expect(page.getByRole('heading', { name: 'OpenAI-compatible provider' })).toBeVisible();
+    await expect(page.getByText('Active')).toHaveCount(1);
   });
 });


### PR DESCRIPTION
## Summary
- updates the image-to-texts Playwright page object for the current local/cloud provider UI
- adds browser coverage for Local/OpenAI-compatible tab switching, cloud model dropdown values, fake key redaction, clear saved key, and switching back to Local
- adds CI-safe Rails integration coverage for saved OpenAI-compatible settings through generate_description, queued job execution, WebMocked provider response, attempt completion, and persisted description
- resets the provider settings singleton between Rails tests to avoid order-dependent leakage

## Verification
- npm run test:e2e -- image-to-texts.spec.ts
- npm run test:e2e
- cd meme_search/meme_search_app && mise exec ruby@3.4.2 -- ruby bin/rails test test/integration/openai_description_generation_test.rb test/controllers/settings/image_to_texts_controller_test.rb test/jobs/generate_image_description_job_test.rb test/services/image_description_providers/openai_provider_test.rb
- cd meme_search/meme_search_app && mise exec ruby@3.4.2 -- ruby bin/rails test
- cd meme_search/image_to_text_generator && PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest
- git diff --check

## Notes
- Required CI does not need a real OpenAI API key or OpenAI network call. The integration test uses http://openai.test/v1 with WebMock and asserts api.openai.com was not requested.
- Manual live OpenAI smoke workflow was split into PR #156.
- GoalBuddy docs/board artifacts are intentionally left uncommitted.
