### PR TITLE
fix: publish app image as multi-arch manifest

### DIFF
--- a/.github/workflows/pro-app-build.yml
+++ b/.github/workflows/pro-app-build.yml
@@ -11,10 +11,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm64]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,8 +59,6 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        with:
-          platforms: ${{ matrix.platform }}
 
       - name: Set Buildx
         uses: docker/setup-buildx-action@v3
@@ -75,17 +69,17 @@ jobs:
         id: start_time
         run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
-      - name: Build and Push for ${{ matrix.platform }}
+      - name: Build and Push for AMD64 and ARM64
         uses: docker/build-push-action@v6
         timeout-minutes: 120
         with:
           context: .
           file: ./meme_search/meme_search_app/Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/neonwatty/meme_search:latest
-          cache-from: type=gha,scope=build-${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=build-${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
 
@@ -95,4 +89,4 @@ jobs:
           END_TIME=$(date +%s)
           DURATION=$((END_TIME - ${{ steps.start_time.outputs.timestamp }}))
           echo "Build duration: $((DURATION / 60)) minutes $((DURATION % 60)) seconds"
-          echo "Platform: ${{ matrix.platform }}"
+          echo "Platforms: linux/amd64,linux/arm64"


### PR DESCRIPTION
## Summary
- replace the Rails app image matrix build with a single buildx multi-platform push
- publish one manifest list for linux/amd64 and linux/arm64 instead of racing two platform-specific pushes to the same latest tag
- keep the root-context Dockerfile fix from #157 intact

## Verification
- parsed .github/workflows/pro-app-build.yml as YAML
- ran git diff --check
- confirmed the previous manual app build succeeded on both platform jobs, but ghcr.io/neonwatty/meme_search:latest only advertised linux/arm64 because the matrix jobs pushed the same tag separately
