### PR TITLE
chore: run GitHub Actions on Node 24

### DIFF
--- a/.github/workflows/openai-live-smoke.yml
+++ b/.github/workflows/openai-live-smoke.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: "https://api.openai.com/v1"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   openai_live_smoke:
     name: OpenAI live description smoke
@@ -35,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips postgresql-client

--- a/.github/workflows/pro-app-build.yml
+++ b/.github/workflows/pro-app-build.yml
@@ -4,6 +4,9 @@ name: "pro app build"
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build_pro_app:
     runs-on: ubuntu-22.04
@@ -13,7 +16,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         run: |
@@ -42,7 +45,7 @@ jobs:
           bundler-cache: true
 
       - name: Log in to Github Docker Image Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -50,7 +53,7 @@ jobs:
 
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.actor }}/meme_search
@@ -58,10 +61,10 @@ jobs:
           flavor: latest=true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: image=moby/buildkit:buildx-stable-1
 
@@ -70,7 +73,7 @@ jobs:
         run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Build and Push for AMD64 and ARM64
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         timeout-minutes: 120
         with:
           context: .

--- a/.github/workflows/pro-app-test.yml
+++ b/.github/workflows/pro-app-test.yml
@@ -21,13 +21,16 @@ on:
       - "!meme_search/meme_search_app/**/*.md"
       - "!meme_search/meme_search_app/**/LICENSE"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate_discord_link:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate Discord link in README.md
         run: bash scripts/validate_discord_link.sh
@@ -37,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -59,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -80,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -116,7 +119,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -176,7 +179,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -186,9 +189,9 @@ jobs:
           working-directory: ./meme_search/meme_search_app
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install Ruby dependencies
@@ -200,7 +203,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -247,7 +250,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload Playwright test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-test-results
@@ -255,7 +258,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Playwright traces
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-traces
@@ -263,7 +266,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/pro-image-to-text-build.yml
+++ b/.github/workflows/pro-image-to-text-build.yml
@@ -4,6 +4,9 @@ name: "pro image to text build"
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build_pro_image_to_text:
     runs-on: ubuntu-22.04
@@ -14,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         run: |
@@ -37,7 +40,7 @@ jobs:
           df -h
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: 'pip'
@@ -61,7 +64,7 @@ jobs:
           done
 
       - name: Log in to Github Docker Image Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -69,7 +72,7 @@ jobs:
 
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.actor }}/image_to_text_generator
@@ -77,10 +80,10 @@ jobs:
           flavor: latest=true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: image=moby/buildkit:buildx-stable-1
 
@@ -89,7 +92,7 @@ jobs:
         run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Build and Upload for AMD64 and ARM64
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         timeout-minutes: 120
         with:
           context: ./meme_search/image_to_text_generator

--- a/.github/workflows/pro-image-to-text-test.yml
+++ b/.github/workflows/pro-image-to-text-test.yml
@@ -9,14 +9,19 @@ on:
       - "!meme_search/image_to_text_generator/**/*.md"
       - "!meme_search/image_to_text_generator/**/LICENSE"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   image_to_text_lint:
     name: image_to_text_lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - uses: chartboost/ruff-action@v1
         with:
           args: "check --fix"
@@ -28,9 +33,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -50,7 +55,7 @@ jobs:
           PYTHONPATH=. python3.12 -m pytest tests/unit/ --cov=app --cov-report=term-missing --cov-report=html --cov-fail-under=60
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: python-coverage-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Create GitHub Release
   create-release:
@@ -16,7 +19,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -35,10 +38,10 @@ jobs:
           echo "Version verified: $TAG_VERSION"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -54,7 +57,7 @@ jobs:
             --tag ghcr.io/neonwatty/image_to_text_generator:v${{ steps.get_version.outputs.version }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: Release v${{ steps.get_version.outputs.version }}
           generate_release_notes: true


### PR DESCRIPTION
Updates active GitHub workflows after the Node 20 deprecation warnings seen during the release.

Changes:
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to active workflows that were missing it.
- Moves the Playwright E2E job from Node 20 to Node 24.
- Updates first-party, Docker, and release actions to current major versions where available.
- Updates the Python service test workflow off older checkout/setup-python pins.

Validation:
- Parsed all workflow YAML files with Ruby.
- Ran `git diff --check`.
- Scanned active workflows for remaining old action pins and explicit Node 20 usage.
