### PR TITLE
Normalize image inputs before captioning

### DIFF
--- a/meme_search/image_to_text_generator/app/model_init.py
+++ b/meme_search/image_to_text_generator/app/model_init.py
@@ -26,17 +26,22 @@ tokenizer = None
 def load_rgb_image(image_path):
     image = Image.open(image_path)
     mode = getattr(image, "mode", None)
+    image_info = getattr(image, "info", {})
+    has_transparency = isinstance(image_info, dict) and image_info.get("transparency") is not None
+    has_alpha = mode in ("RGBA", "LA") or has_transparency
+
+    if has_alpha:
+        image_rgba = image.convert("RGBA")
+        background = Image.new("RGBA", image_rgba.size, (255, 255, 255, 255))
+        background.alpha_composite(image_rgba)
+        converted_image = background.convert("RGB")
+        image_rgba.close()
+        background.close()
+        image.close()
+        return converted_image
+
     if isinstance(mode, str) and mode != "RGB":
-        has_alpha = mode in ("RGBA", "LA") or image.info.get("transparency") is not None
-        if has_alpha:
-            image_rgba = image.convert("RGBA")
-            background = Image.new("RGBA", image_rgba.size, (255, 255, 255, 255))
-            background.alpha_composite(image_rgba)
-            converted_image = background.convert("RGB")
-            image_rgba.close()
-            background.close()
-        else:
-            converted_image = image.convert("RGB")
+        converted_image = image.convert("RGB")
         image.close()
         return converted_image
 

--- a/meme_search/image_to_text_generator/app/model_init.py
+++ b/meme_search/image_to_text_generator/app/model_init.py
@@ -23,6 +23,17 @@ model = None
 tokenizer = None
 
 
+def load_rgb_image(image_path):
+    image = Image.open(image_path)
+    mode = getattr(image, "mode", None)
+    if isinstance(mode, str) and mode != "RGB":
+        converted_image = image.convert("RGB")
+        image.close()
+        return converted_image
+
+    return image
+
+
 class TestImageToText:
     """
     Test/dummy model for E2E testing that doesn't require actual ML inference.
@@ -89,7 +100,7 @@ class MoondreamImageToText:
             logging.info("INFO: model downloaded, starting image processing")
 
         # load in image
-        image = Image.open(image_path)
+        image = load_rgb_image(image_path)
         logging.info(f"DONE: image loaded, starting generation --> {image_path}")
 
         # process image
@@ -165,7 +176,7 @@ class MoondreamQuantizedImageToText:
             logging.info("INFO: model downloaded, starting image processing")
 
         # load in image
-        image = Image.open(image_path)
+        image = load_rgb_image(image_path)
         logging.info(f"DONE: image loaded, starting generation --> {image_path}")
 
         # process image
@@ -215,7 +226,7 @@ class Florence2BaseImageToText:
 
         # load in image
         logging.info(f"INFO: starting image to text extraction for image {image_path}...")
-        image = Image.open(image_path)
+        image = load_rgb_image(image_path)
         task = "<DETAILED_CAPTION>"
         inputs = self.processor(text=task, images=image, return_tensors="pt").to(device, torch_dtype)
         generated_ids = self.model.generate(
@@ -275,7 +286,7 @@ class Florence2LargeImageToText:
 
         # load in image
         logging.info(f"INFO: starting image to text extraction for image {image_path}...")
-        image = Image.open(image_path)
+        image = load_rgb_image(image_path)
         task = "<DETAILED_CAPTION>"
         inputs = self.processor(text=task, images=image, return_tensors="pt").to(device, torch_dtype)
         generated_ids = self.model.generate(
@@ -341,7 +352,7 @@ class SmolVLM256ImageToText:
 
         # load in image
         print(f"INFO: starting image to text extraction for image {image_path}...")
-        image = Image.open(image_path)
+        image = load_rgb_image(image_path)
         # Create input messages
         messages = [
             {
@@ -427,7 +438,7 @@ class SmolVLM500ImageToText:
 
         # load in image
         print(f"INFO: starting image to text extraction for image {image_path}...")
-        image = Image.open(image_path)
+        image = load_rgb_image(image_path)
         # Create input messages
         messages = [
             {

--- a/meme_search/image_to_text_generator/app/model_init.py
+++ b/meme_search/image_to_text_generator/app/model_init.py
@@ -27,7 +27,16 @@ def load_rgb_image(image_path):
     image = Image.open(image_path)
     mode = getattr(image, "mode", None)
     if isinstance(mode, str) and mode != "RGB":
-        converted_image = image.convert("RGB")
+        has_alpha = mode in ("RGBA", "LA") or image.info.get("transparency") is not None
+        if has_alpha:
+            image_rgba = image.convert("RGBA")
+            background = Image.new("RGBA", image_rgba.size, (255, 255, 255, 255))
+            background.alpha_composite(image_rgba)
+            converted_image = background.convert("RGB")
+            image_rgba.close()
+            background.close()
+        else:
+            converted_image = image.convert("RGB")
         image.close()
         return converted_image
 

--- a/meme_search/image_to_text_generator/tests/unit/test_model_init.py
+++ b/meme_search/image_to_text_generator/tests/unit/test_model_init.py
@@ -60,6 +60,16 @@ def test_load_rgb_image_flattens_transparency_on_white(tmp_path):
     assert image.getpixel((0, 0)) == (255, 255, 255)
 
 
+def test_load_rgb_image_flattens_rgb_png_transparency_on_white(tmp_path):
+    image_path = tmp_path / "rgb-trns.png"
+    Image.new("RGB", (1, 1), (255, 0, 0)).save(image_path, transparency=(255, 0, 0))
+
+    image = load_rgb_image(image_path)
+
+    assert image.mode == "RGB"
+    assert image.getpixel((0, 0)) == (255, 255, 255)
+
+
 class TestTestImageToText:
     """Test suite for TestImageToText model (test/mock model)"""
 

--- a/meme_search/image_to_text_generator/tests/unit/test_model_init.py
+++ b/meme_search/image_to_text_generator/tests/unit/test_model_init.py
@@ -318,6 +318,46 @@ class TestFlorence2BaseImageToText:
         assert result == 'A detailed caption of the image'
         assert model.downloaded is True
 
+    def test_extract_converts_rgba_png_before_processor_call(self, tmp_path):
+        """Test Florence-2-base normalizes the issue's RGBA PNG failure mode"""
+        image_path = tmp_path / "Screenshot 2026-01-10 155711.png"
+        Image.new("RGBA", (3, 2), (255, 0, 0, 128)).save(image_path)
+
+        captured = {}
+        mock_inputs = {"input_ids": MagicMock(), "pixel_values": MagicMock()}
+        mock_inputs_with_to = MagicMock()
+        mock_inputs_with_to.__getitem__ = lambda self, key: mock_inputs[key]
+
+        mock_processor_instance = MagicMock()
+
+        def process_image(text, images, return_tensors):
+            captured["text"] = text
+            captured["images"] = images
+            captured["return_tensors"] = return_tensors
+            return mock_inputs_with_to
+
+        mock_processor_instance.side_effect = process_image
+        mock_processor_instance.batch_decode.return_value = ["generated text"]
+        mock_processor_instance.post_process_generation.return_value = {
+            '<DETAILED_CAPTION>': 'A caption for an RGBA screenshot'
+        }
+
+        mock_model_instance = MagicMock()
+        mock_model_instance.generate.return_value = [1, 2, 3]
+
+        model = Florence2BaseImageToText(model_id="microsoft/Florence-2-base", revision="2024-08-26")
+        model.model = mock_model_instance
+        model.processor = mock_processor_instance
+        model.downloaded = True
+
+        result = model.extract(str(image_path))
+
+        assert result == "A caption for an RGBA screenshot"
+        assert captured["text"] == "<DETAILED_CAPTION>"
+        assert captured["return_tensors"] == "pt"
+        assert captured["images"].mode == "RGB"
+        assert captured["images"].size == (3, 2)
+
     @patch('model_init.Image.open')
     @patch('model_init.AutoProcessor.from_pretrained')
     @patch('model_init.AutoModelForCausalLM.from_pretrained')

--- a/meme_search/image_to_text_generator/tests/unit/test_model_init.py
+++ b/meme_search/image_to_text_generator/tests/unit/test_model_init.py
@@ -14,8 +14,40 @@ from model_init import (
     Florence2LargeImageToText,
     SmolVLM256ImageToText,
     SmolVLM500ImageToText,
+    load_rgb_image,
     model_selector
 )
+
+from PIL import Image
+
+
+def test_load_rgb_image_keeps_rgb_images(tmp_path):
+    image_path = tmp_path / "rgb.jpg"
+    Image.new("RGB", (2, 2), (255, 0, 0)).save(image_path)
+
+    image = load_rgb_image(image_path)
+
+    assert image.mode == "RGB"
+    assert image.size == (2, 2)
+
+
+@pytest.mark.parametrize(
+    ("mode", "filename"),
+    [
+        ("RGBA", "transparent.png"),
+        ("LA", "luminance-alpha.png"),
+        ("L", "grayscale.png"),
+        ("P", "palette.png"),
+    ],
+)
+def test_load_rgb_image_converts_non_rgb_images(tmp_path, mode, filename):
+    image_path = tmp_path / filename
+    Image.new(mode, (2, 2)).save(image_path)
+
+    image = load_rgb_image(image_path)
+
+    assert image.mode == "RGB"
+    assert image.size == (2, 2)
 
 
 class TestTestImageToText:
@@ -361,6 +393,42 @@ class TestFlorence2LargeImageToText:
         assert call_args[0][0] == "microsoft/Florence-2-large"
         assert call_args[1]["trust_remote_code"] is True
 
+    @patch('model_init.load_rgb_image')
+    def test_extract_uses_rgb_image_and_returns_detailed_caption(self, mock_load_rgb_image):
+        """Test extract normalizes image input before processor call"""
+        mock_pil_image = MagicMock()
+        mock_pil_image.width = 800
+        mock_pil_image.height = 600
+        mock_load_rgb_image.return_value = mock_pil_image
+
+        mock_processor_instance = MagicMock()
+        mock_inputs = {"input_ids": MagicMock(), "pixel_values": MagicMock()}
+        mock_inputs_with_to = MagicMock()
+        mock_inputs_with_to.__getitem__ = lambda self, key: mock_inputs[key]
+        mock_processor_instance.return_value = mock_inputs_with_to
+        mock_processor_instance.batch_decode.return_value = ["generated text"]
+        mock_processor_instance.post_process_generation.return_value = {
+            '<DETAILED_CAPTION>': 'A large model caption'
+        }
+
+        mock_model_instance = MagicMock()
+        mock_model_instance.generate.return_value = [1, 2, 3]
+
+        model = Florence2LargeImageToText(model_id="microsoft/Florence-2-large", revision="2024-08-26")
+        model.model = mock_model_instance
+        model.processor = mock_processor_instance
+        model.downloaded = True
+
+        result = model.extract("rgba.png")
+
+        assert result == "A large model caption"
+        mock_load_rgb_image.assert_called_once_with("rgba.png")
+        mock_processor_instance.assert_called_once_with(
+            text="<DETAILED_CAPTION>",
+            images=mock_pil_image,
+            return_tensors="pt"
+        )
+
 
 class TestSmolVLM256ImageToText:
     """Test suite for SmolVLM256ImageToText model"""
@@ -470,6 +538,39 @@ class TestSmolVLM500ImageToText:
         call_args = mock_model.call_args
         assert call_args[0][0] == "HuggingFaceTB/SmolVLM-500M-Instruct"
         assert call_args[1]["_attn_implementation"] == "eager"
+
+    @patch('model_init.load_rgb_image')
+    def test_extract_uses_rgb_image_and_cleans_output_text(self, mock_load_rgb_image):
+        """Test extract normalizes image input and removes prompt text"""
+        mock_pil_image = MagicMock()
+        mock_load_rgb_image.return_value = mock_pil_image
+
+        mock_processor_instance = MagicMock()
+        mock_processor_instance.apply_chat_template.return_value = "template"
+        mock_inputs = MagicMock()
+        mock_inputs.to.return_value = mock_inputs
+        mock_processor_instance.return_value = mock_inputs
+        mock_processor_instance.batch_decode.return_value = [
+            "Can you describe this image?Assistant: Clean 500M caption### Analysis and Description: extra text"
+        ]
+
+        mock_model_instance = MagicMock()
+        mock_model_instance.generate.return_value = [1, 2, 3]
+
+        model = SmolVLM500ImageToText(model_id="HuggingFaceTB/SmolVLM-500M-Instruct", revision="2024-08-26")
+        model.model = mock_model_instance
+        model.processor = mock_processor_instance
+        model.downloaded = True
+
+        result = model.extract("grayscale.png")
+
+        assert result == "Clean 500M caption"
+        mock_load_rgb_image.assert_called_once_with("grayscale.png")
+        mock_processor_instance.assert_called_once_with(
+            text="template",
+            images=[mock_pil_image],
+            return_tensors="pt"
+        )
 
 
 class TestModelSelector:

--- a/meme_search/image_to_text_generator/tests/unit/test_model_init.py
+++ b/meme_search/image_to_text_generator/tests/unit/test_model_init.py
@@ -50,6 +50,16 @@ def test_load_rgb_image_converts_non_rgb_images(tmp_path, mode, filename):
     assert image.size == (2, 2)
 
 
+def test_load_rgb_image_flattens_transparency_on_white(tmp_path):
+    image_path = tmp_path / "transparent-hidden-red.png"
+    Image.new("RGBA", (1, 1), (255, 0, 0, 0)).save(image_path)
+
+    image = load_rgb_image(image_path)
+
+    assert image.mode == "RGB"
+    assert image.getpixel((0, 0)) == (255, 255, 255)
+
+
 class TestTestImageToText:
     """Test suite for TestImageToText model (test/mock model)"""
 
@@ -357,6 +367,7 @@ class TestFlorence2BaseImageToText:
         assert captured["return_tensors"] == "pt"
         assert captured["images"].mode == "RGB"
         assert captured["images"].size == (3, 2)
+        assert captured["images"].getpixel((0, 0)) == (255, 127, 127)
 
     @patch('model_init.Image.open')
     @patch('model_init.AutoProcessor.from_pretrained')


### PR DESCRIPTION
## Summary

Normalizes local image-to-text model inputs to RGB before caption generation for #147.

- Adds a shared `load_rgb_image` helper.
- Uses it across local captioning models before processor/model inference.
- Covers RGB passthrough plus RGBA, LA, grayscale, and palette images.
- Adds extraction regression checks for Florence large and SmolVLM 500M using normalized image inputs.

Closes #147.

## Validation

- `/Users/neonwatty/Desktop/meme-search/meme_search/image_to_text_generator/.venv/bin/python -m pytest meme_search/image_to_text_generator/tests/unit/test_model_init.py` - 39 passed
