### PR TITLE
Fix Compose internal database URL

### DIFF
--- a/.github/workflows/docker-compose-database-url-test.yml
+++ b/.github/workflows/docker-compose-database-url-test.yml
@@ -1,0 +1,32 @@
+name: Docker Compose database URL tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["main", "develop"]
+    paths:
+      - "docker-compose*.yml"
+      - "scripts/test_compose_database_url.sh"
+      - ".github/workflows/docker-compose-database-url-test.yml"
+      - "README.md"
+  push:
+    branches: ["main", "develop"]
+    paths:
+      - "docker-compose*.yml"
+      - "scripts/test_compose_database_url.sh"
+      - ".github/workflows/docker-compose-database-url-test.yml"
+      - "README.md"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  docker_compose_database_url:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate Compose database URLs
+        run: bash scripts/test_compose_database_url.sh

--- a/README.md
+++ b/README.md
@@ -276,9 +276,10 @@ To customize the main app port create a `.env` file locally in the root of the d
 
 ```sh
 APP_PORT= # the port for the app - defaults to 3000
+DB_PORT= # optional host port for Postgres - defaults to 5432
 ```
 
-This value is automatically detected and loaded into each service via the `docker-compose-pro.yml` file.
+These values are automatically detected and loaded into each service via the Compose files. `DB_PORT` only changes the host port published by the Postgres service. Do not use `DB_PORT` inside `DATABASE_URL`; app containers talk to Postgres over Docker's internal network at `meme-search-db:5432`.
 
 ### Building the app locally with Docker
 

--- a/README.md
+++ b/README.md
@@ -276,10 +276,9 @@ To customize the main app port create a `.env` file locally in the root of the d
 
 ```sh
 APP_PORT= # the port for the app - defaults to 3000
-DB_PORT= # optional host port for Postgres - defaults to 5432
 ```
 
-These values are automatically detected and loaded into each service via the Compose files. `DB_PORT` only changes the host port published by the Postgres service. Do not use `DB_PORT` inside `DATABASE_URL`; app containers talk to Postgres over Docker's internal network at `meme-search-db:5432`.
+This value is automatically detected and loaded into each service via the Compose files. The Postgres service is only exposed on Docker's internal network, so app containers always talk to it at `meme-search-db:5432`.
 
 ### Building the app locally with Docker
 

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./meme_search/meme_search_app/Dockerfile
     container_name: meme_search
     environment:
-      DATABASE_URL: "postgres://postgres:postgres@meme-search-db:${DB_PORT:-5432}/meme_search"
+      DATABASE_URL: "postgres://postgres:postgres@meme-search-db:5432/meme_search"
       IMAGE_DESCRIPTION_PROVIDER: "${IMAGE_DESCRIPTION_PROVIDER:-local}"
       OPENAI_API_BASE_URL: "${OPENAI_API_BASE_URL:-}"
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
@@ -27,7 +27,7 @@ services:
     container_name: meme_search_jobs
     command: ./bin/jobs
     environment:
-      DATABASE_URL: "postgres://postgres:postgres@meme-search-db:${DB_PORT:-5432}/meme_search"
+      DATABASE_URL: "postgres://postgres:postgres@meme-search-db:5432/meme_search"
       IMAGE_DESCRIPTION_PROVIDER: "${IMAGE_DESCRIPTION_PROVIDER:-local}"
       OPENAI_API_BASE_URL: "${OPENAI_API_BASE_URL:-}"
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"

--- a/scripts/run_all_ci_tests.sh
+++ b/scripts/run_all_ci_tests.sh
@@ -123,14 +123,6 @@ if [ ! -f "package.json" ] || [ ! -d "meme_search" ]; then
 fi
 echo -e "${GREEN}✓ Running from project root${NC}"
 
-print_header "Docker Compose: Database URL Tests"
-if bash scripts/test_compose_database_url.sh; then
-    echo -e "${GREEN}✓ Docker Compose database URL tests passed${NC}"
-else
-    echo -e "${RED}❌ Docker Compose database URL tests failed${NC}"
-    track_failure "Docker Compose: Database URL Tests"
-fi
-
 # Parse command line arguments
 SKIP_E2E=false
 SKIP_RAILS=false

--- a/scripts/run_all_ci_tests.sh
+++ b/scripts/run_all_ci_tests.sh
@@ -123,6 +123,14 @@ if [ ! -f "package.json" ] || [ ! -d "meme_search" ]; then
 fi
 echo -e "${GREEN}✓ Running from project root${NC}"
 
+print_header "Docker Compose: Database URL Tests"
+if bash scripts/test_compose_database_url.sh; then
+    echo -e "${GREEN}✓ Docker Compose database URL tests passed${NC}"
+else
+    echo -e "${RED}❌ Docker Compose database URL tests failed${NC}"
+    track_failure "Docker Compose: Database URL Tests"
+fi
+
 # Parse command line arguments
 SKIP_E2E=false
 SKIP_RAILS=false

--- a/scripts/test_compose_database_url.sh
+++ b/scripts/test_compose_database_url.sh
@@ -3,22 +3,27 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-rendered_config="$(mktemp)"
-trap 'rm -f "$rendered_config"' EXIT
+rendered_configs=()
+trap 'rm -f "${rendered_configs[@]}"' EXIT
 
-(
-    cd "$ROOT_DIR"
-    DB_PORT=15432 docker compose -f docker-compose-local-build.yml config > "$rendered_config"
-)
+for compose_file in docker-compose.yml docker-compose-local-build.yml; do
+    rendered_config="$(mktemp)"
+    rendered_configs+=("$rendered_config")
 
-if grep -Fq "meme-search-db:15432" "$rendered_config"; then
-    echo "❌ DATABASE_URL used host DB_PORT for internal container traffic" >&2
-    exit 1
-fi
+    (
+        cd "$ROOT_DIR"
+        DB_PORT=15432 docker compose -f "$compose_file" config > "$rendered_config"
+    )
 
-grep -Fq "DATABASE_URL: postgres://postgres:postgres@meme-search-db:5432/meme_search" "$rendered_config" || {
-    echo "❌ DATABASE_URL must use the internal Postgres container port 5432" >&2
-    exit 1
-}
+    if grep -Fq "meme-search-db:15432" "$rendered_config"; then
+        echo "❌ $compose_file DATABASE_URL used DB_PORT for internal container traffic" >&2
+        exit 1
+    fi
+
+    grep -Fq "DATABASE_URL: postgres://postgres:postgres@meme-search-db:5432/meme_search" "$rendered_config" || {
+        echo "❌ $compose_file DATABASE_URL must use the internal Postgres container port 5432" >&2
+        exit 1
+    }
+done
 
 echo "✓ Docker Compose database URL tests passed"

--- a/scripts/test_compose_database_url.sh
+++ b/scripts/test_compose_database_url.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rendered_config="$(mktemp)"
+trap 'rm -f "$rendered_config"' EXIT
+
+(
+    cd "$ROOT_DIR"
+    DB_PORT=15432 docker compose -f docker-compose-local-build.yml config > "$rendered_config"
+)
+
+if grep -Fq "meme-search-db:15432" "$rendered_config"; then
+    echo "❌ DATABASE_URL used host DB_PORT for internal container traffic" >&2
+    exit 1
+fi
+
+grep -Fq "DATABASE_URL: postgres://postgres:postgres@meme-search-db:5432/meme_search" "$rendered_config" || {
+    echo "❌ DATABASE_URL must use the internal Postgres container port 5432" >&2
+    exit 1
+}
+
+echo "✓ Docker Compose database URL tests passed"


### PR DESCRIPTION
## Summary

Fixes the local-build Compose database URL reported in #111.

- Keeps `DB_PORT` for host-published Postgres access only.
- Uses the internal container port `5432` in Rails and job worker `DATABASE_URL`.
- Adds a focused Compose regression script and wires it into the unified CI runner.

Closes #111.

## Validation

- `bash scripts/test_compose_database_url.sh`
