### PR TITLE
Add clipboard image upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Features of Meme Search include:
 
 11. **Drag-and-Drop Upload**
 
-   Upload memes directly through the web interface with drag-and-drop support. Files are stored in the `direct-uploads` directory (configurable via Docker volume mount) and automatically scanned for indexing. Supports JPG, PNG, and WEBP formats with bulk upload (up to 50 files), real-time progress tracking, and automatic duplicate filename handling.
+   Upload memes directly through the web interface with drag-and-drop and clipboard paste support. Files are stored in the `direct-uploads` directory (configurable via Docker volume mount) and automatically scanned for indexing. Supports JPG, PNG, and WEBP formats with bulk upload (up to 50 files), real-time progress tracking, and automatic duplicate filename handling.
 
 ### Requirements
 

--- a/meme_search/meme_search_app/app/javascript/controllers/file_upload_controller.js
+++ b/meme_search/meme_search_app/app/javascript/controllers/file_upload_controller.js
@@ -59,6 +59,40 @@ export default class extends Controller {
     this.addFiles(files);
   }
 
+  handlePaste(event) {
+    const clipboardItems = Array.from(event.clipboardData?.items || []);
+    const pastedFiles = clipboardItems
+      .filter((item) => item.kind === "file")
+      .map((item) => item.getAsFile())
+      .filter((file) => file && file.type.match(/^image\/(jpeg|jpg|png|webp)$/))
+      .map((file, index) => this.withClipboardFilename(file, index));
+
+    if (pastedFiles.length === 0) return;
+
+    event.preventDefault();
+    this.addFiles(pastedFiles);
+  }
+
+  withClipboardFilename(file, index) {
+    if (file.name && !file.name.match(/^image\.(png|jpe?g|webp)$/i)) {
+      return file;
+    }
+
+    const extensionsByType = {
+      "image/jpeg": "jpg",
+      "image/jpg": "jpg",
+      "image/png": "png",
+      "image/webp": "webp",
+    };
+    const extension = extensionsByType[file.type] || "png";
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+    return new File([file], `clipboard-${timestamp}-${index + 1}.${extension}`, {
+      type: file.type,
+      lastModified: file.lastModified,
+    });
+  }
+
   // Add files to the list
   addFiles(newFiles) {
     // Filter for images only

--- a/meme_search/meme_search_app/app/javascript/controllers/file_upload_controller.js
+++ b/meme_search/meme_search_app/app/javascript/controllers/file_upload_controller.js
@@ -61,13 +61,23 @@ export default class extends Controller {
 
   handlePaste(event) {
     const clipboardItems = Array.from(event.clipboardData?.items || []);
+    const pastedFileItems = clipboardItems.filter((item) => item.kind === "file");
     const pastedFiles = clipboardItems
       .filter((item) => item.kind === "file")
       .map((item) => item.getAsFile())
       .filter((file) => file && file.type.match(/^image\/(jpeg|jpg|png|webp)$/))
       .map((file, index) => this.withClipboardFilename(file, index));
 
-    if (pastedFiles.length === 0) return;
+    if (pastedFiles.length === 0) {
+      const pastedImageItems = pastedFileItems.filter((item) => item.type.match(/^image\//));
+
+      if (pastedImageItems.length > 0) {
+        event.preventDefault();
+        this.showError("Pasted image format is not supported. Use JPG, PNG, or WEBP.");
+      }
+
+      return;
+    }
 
     event.preventDefault();
     this.addFiles(pastedFiles);

--- a/meme_search/meme_search_app/app/views/image_uploads/new.html.erb
+++ b/meme_search/meme_search_app/app/views/image_uploads/new.html.erb
@@ -1,8 +1,8 @@
-<div class="flex flex-col items-center justify-center px-4 py-8" data-controller="file-upload">
+<div class="flex flex-col items-center justify-center px-4 py-8" data-controller="file-upload" data-action="paste@window->file-upload#handlePaste">
   <!-- Page Header -->
   <div class="text-center mb-6">
     <h1 class="text-3xl font-bold text-gray-800 dark:text-white">Upload Images</h1>
-    <p class="text-gray-600 dark:text-gray-400 mt-2">Drag and drop images or click to browse</p>
+    <p class="text-gray-600 dark:text-gray-400 mt-2">Drag and drop, paste, or click to browse</p>
   </div>
 
   <!-- Glassmorphic Card Wrapper -->
@@ -32,7 +32,7 @@
 
       <label for="file-input" class="cursor-pointer">
         <span class="text-blue-600 dark:text-blue-400 font-medium hover:underline">Click to upload</span>
-        <span class="text-gray-600 dark:text-gray-400"> or drag and drop</span>
+        <span class="text-gray-600 dark:text-gray-400">, drag and drop, or paste</span>
       </label>
 
       <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">

--- a/meme_search/meme_search_app/test/controllers/image_uploads_controller_test.rb
+++ b/meme_search/meme_search_app/test/controllers/image_uploads_controller_test.rb
@@ -5,12 +5,13 @@ class ImageUploadsControllerTest < ActionDispatch::IntegrationTest
   def setup
     @upload_dir = Rails.root.join("public", "memes", "direct-uploads")
     FileUtils.mkdir_p(@upload_dir)
+    @existing_upload_files = Dir.glob(File.join(@upload_dir, "*")).select { |file| File.file?(file) }
   end
 
   def teardown
     # Clean up test uploads
     Dir.glob(File.join(@upload_dir, "*")).each do |file|
-      File.delete(file) if File.file?(file)
+      File.delete(file) if File.file?(file) && !@existing_upload_files.include?(file)
     end
   end
 

--- a/playwright/pages/image-uploads.page.ts
+++ b/playwright/pages/image-uploads.page.ts
@@ -13,8 +13,8 @@ export class ImageUploadsPage {
   }
 
   async getHeading(): Promise<string> {
-    const heading = await this.page.locator('h1').first();
-    return heading.textContent() || '';
+    const heading = this.page.locator('h1').first();
+    return (await heading.textContent()) || '';
   }
 
   async isDropzoneVisible(): Promise<boolean> {
@@ -32,10 +32,44 @@ export class ImageUploadsPage {
     await fileInput.setInputFiles(filePath);
   }
 
+  async pasteImage(base64Image: string, filename = 'clipboard.png', mimeType = 'image/png') {
+    await this.pasteFiles([{ base64: base64Image, filename, mimeType }]);
+  }
+
+  async pasteFiles(files: Array<{ base64: string; filename: string; mimeType: string }>) {
+    await this.page.evaluate(
+      ({ files }) => {
+        const browserGlobal = globalThis as any;
+        const dataTransfer = new browserGlobal.DataTransfer();
+
+        for (const fileDetails of files) {
+          const bytes = Uint8Array.from(browserGlobal.atob(fileDetails.base64), (character: string) => character.charCodeAt(0));
+          const file = new browserGlobal.File([bytes], fileDetails.filename, { type: fileDetails.mimeType });
+          dataTransfer.items.add(file);
+        }
+
+        const pasteEvent = new browserGlobal.Event('paste', { bubbles: true, cancelable: true });
+
+        Object.defineProperty(pasteEvent, 'clipboardData', {
+          value: dataTransfer,
+        });
+
+        browserGlobal.dispatchEvent(pasteEvent);
+      },
+      { files }
+    );
+  }
+
   async getPreviewCount(): Promise<number> {
     const preview = this.page.locator('[data-file-upload-target="preview"]');
     const items = preview.locator('> div');
     return items.count();
+  }
+
+  async getPreviewFilenames(): Promise<string[]> {
+    return this.page
+      .locator('[data-file-upload-target="preview"] p.text-sm')
+      .evaluateAll((nodes) => nodes.map((node) => node.textContent?.trim() || ''));
   }
 
   async clickUpload() {

--- a/playwright/tests/image-uploads.spec.ts
+++ b/playwright/tests/image-uploads.spec.ts
@@ -17,6 +17,8 @@ test.describe('Image Uploads', () => {
   let imagePathsPage: ImagePathsPage;
   const testImagePath = path.join(__dirname, '../fixtures/test-image.jpg');
   const testInvalidPath = path.join(__dirname, '../fixtures/test-file.txt');
+  const directUploadsPath = path.join(__dirname, '../../meme_search/meme_search_app/public/memes/direct-uploads');
+  const jpegBase64 = '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCwAA//2Q==';
 
   // Setup test fixtures
   test.beforeAll(async () => {
@@ -27,7 +29,6 @@ test.describe('Image Uploads', () => {
     }
 
     // Create a simple test image (1x1 pixel JPEG)
-    const jpegBase64 = '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCwAA//2Q==';
     fs.writeFileSync(testImagePath, Buffer.from(jpegBase64, 'base64'));
 
     // Create a test text file (invalid type)
@@ -51,12 +52,26 @@ test.describe('Image Uploads', () => {
     imagePathsPage = new ImagePathsPage(page);
   });
 
+  test.afterEach(async () => {
+    if (!fs.existsSync(directUploadsPath)) return;
+
+    for (const filename of fs.readdirSync(directUploadsPath)) {
+      if (filename === '.gitkeep') continue;
+
+      const uploadedFilePath = path.join(directUploadsPath, filename);
+      if (fs.statSync(uploadedFilePath).isFile()) {
+        fs.unlinkSync(uploadedFilePath);
+      }
+    }
+  });
+
   test('should display upload page with drag-drop zone', async ({ page }) => {
     await imageUploadsPage.goto();
 
     // Verify page heading
     const heading = await imageUploadsPage.getHeading();
     expect(heading).toContain('Upload Images');
+    await expect(page.getByText('Drag and drop, paste, or click to browse')).toBeVisible();
 
     // Verify dropzone is visible
     const dropzoneVisible = await imageUploadsPage.isDropzoneVisible();
@@ -93,6 +108,69 @@ test.describe('Image Uploads', () => {
     // Verify success message
     const hasSuccess = await imageUploadsPage.hasSuccessMessage();
     expect(hasSuccess).toBe(true);
+  });
+
+  test('should add pasted clipboard image to upload queue', async ({ page }) => {
+    await imageUploadsPage.goto();
+
+    await imageUploadsPage.pasteImage(jpegBase64, 'image.png', 'image/png');
+    await page.waitForTimeout(500);
+
+    const previewCount = await imageUploadsPage.getPreviewCount();
+    expect(previewCount).toBe(1);
+    const previewFilenames = await imageUploadsPage.getPreviewFilenames();
+    expect(previewFilenames[0]).toMatch(/^clipboard-.*-1\.png$/);
+
+    const uploadButtonDisabled = await imageUploadsPage.isUploadButtonDisabled();
+    expect(uploadButtonDisabled).toBe(false);
+  });
+
+  test('should preserve useful pasted image filenames', async ({ page }) => {
+    await imageUploadsPage.goto();
+
+    await imageUploadsPage.pasteImage(jpegBase64, 'copied-meme.jpg', 'image/jpeg');
+    await page.waitForTimeout(500);
+
+    await expect(page.getByText('copied-meme.jpg')).toBeVisible();
+  });
+
+  test('should add multiple pasted images in one paste event', async ({ page }) => {
+    await imageUploadsPage.goto();
+
+    await imageUploadsPage.pasteFiles([
+      { base64: jpegBase64, filename: 'image.png', mimeType: 'image/png' },
+      { base64: jpegBase64, filename: 'second.jpg', mimeType: 'image/jpeg' },
+    ]);
+    await page.waitForTimeout(500);
+
+    const previewFilenames = await imageUploadsPage.getPreviewFilenames();
+    expect(previewFilenames).toHaveLength(2);
+    expect(previewFilenames[0]).toMatch(/^clipboard-.*-1\.png$/);
+    expect(previewFilenames[1]).toBe('second.jpg');
+    expect(await imageUploadsPage.isUploadButtonDisabled()).toBe(false);
+  });
+
+  test('should ignore pasted non-image files without enabling upload', async ({ page }) => {
+    await imageUploadsPage.goto();
+
+    await imageUploadsPage.pasteFiles([
+      { base64: Buffer.from('not an image').toString('base64'), filename: 'notes.txt', mimeType: 'text/plain' },
+    ]);
+    await page.waitForTimeout(500);
+
+    expect(await imageUploadsPage.getPreviewCount()).toBe(0);
+    expect(await imageUploadsPage.isUploadButtonDisabled()).toBe(true);
+  });
+
+  test('should upload a pasted clipboard image', async ({ page }) => {
+    await imageUploadsPage.goto();
+
+    await imageUploadsPage.pasteImage(jpegBase64, 'image.png', 'image/png');
+    await page.waitForTimeout(500);
+    await imageUploadsPage.clickUpload();
+    await page.waitForTimeout(1000);
+
+    expect(await imageUploadsPage.hasSuccessMessage()).toBe(true);
   });
 
   test('should upload multiple image files', async ({ page }) => {

--- a/playwright/tests/image-uploads.spec.ts
+++ b/playwright/tests/image-uploads.spec.ts
@@ -15,6 +15,7 @@ import * as fs from 'fs';
 test.describe('Image Uploads', () => {
   let imageUploadsPage: ImageUploadsPage;
   let imagePathsPage: ImagePathsPage;
+  let directUploadsSnapshot: Set<string>;
   const testImagePath = path.join(__dirname, '../fixtures/test-image.jpg');
   const testInvalidPath = path.join(__dirname, '../fixtures/test-file.txt');
   const directUploadsPath = path.join(__dirname, '../../meme_search/meme_search_app/public/memes/direct-uploads');
@@ -47,6 +48,11 @@ test.describe('Image Uploads', () => {
 
   // Reset database before each test
   test.beforeEach(async ({ page }) => {
+    if (!fs.existsSync(directUploadsPath)) {
+      fs.mkdirSync(directUploadsPath, { recursive: true });
+    }
+
+    directUploadsSnapshot = new Set(fs.readdirSync(directUploadsPath));
     await resetTestDatabase();
     imageUploadsPage = new ImageUploadsPage(page);
     imagePathsPage = new ImagePathsPage(page);
@@ -56,7 +62,7 @@ test.describe('Image Uploads', () => {
     if (!fs.existsSync(directUploadsPath)) return;
 
     for (const filename of fs.readdirSync(directUploadsPath)) {
-      if (filename === '.gitkeep') continue;
+      if (directUploadsSnapshot.has(filename)) continue;
 
       const uploadedFilePath = path.join(directUploadsPath, filename);
       if (fs.statSync(uploadedFilePath).isFile()) {
@@ -160,6 +166,19 @@ test.describe('Image Uploads', () => {
 
     expect(await imageUploadsPage.getPreviewCount()).toBe(0);
     expect(await imageUploadsPage.isUploadButtonDisabled()).toBe(true);
+  });
+
+  test('should show an error for unsupported pasted image formats', async ({ page }) => {
+    await imageUploadsPage.goto();
+
+    await imageUploadsPage.pasteFiles([
+      { base64: Buffer.from('gif bytes').toString('base64'), filename: 'animated.gif', mimeType: 'image/gif' },
+    ]);
+    await page.waitForTimeout(500);
+
+    expect(await imageUploadsPage.getPreviewCount()).toBe(0);
+    expect(await imageUploadsPage.isUploadButtonDisabled()).toBe(true);
+    await expect(page.getByText('Pasted image format is not supported. Use JPG, PNG, or WEBP.')).toBeVisible();
   });
 
   test('should upload a pasted clipboard image', async ({ page }) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Adds clipboard paste support to the upload flow for #150.

- Handles pasted image files from the browser clipboard.
- Gives generic clipboard files stable upload filenames like `clipboard-...png`.
- Preserves useful pasted filenames when the browser provides them.
- Expands Playwright coverage for paste copy, multi-image paste, non-image clipboard ignores, and pasted-image upload.

Closes #150.

## Validation

- `npx tsc --noEmit`
- `CI=1 BASE_URL=http://localhost:3002 npx playwright test playwright/tests/image-uploads.spec.ts` - 13 passed
