### PR TITLE
chore: add Discord release notification workflow

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -1,0 +1,185 @@
+name: Discord Release Notification
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to post, such as v2.2.0
+        required: true
+        type: string
+      message:
+        description: Optional custom message above the release embed
+        required: false
+        type: string
+      image_url:
+        description: Optional public image URL to include in the embed
+        required: false
+        type: string
+      mention_user_id:
+        description: Optional Discord user ID allowed for a real mention; use {mention} in message
+        required: false
+        type: string
+      dry_run:
+        description: Print the Discord payload without posting
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  notify-discord:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send release notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+          const repository = process.env.GITHUB_REPOSITORY;
+          const inputs = event.inputs || {};
+          const isManualRun = process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';
+
+          async function fetchReleaseByTag(tag) {
+            const headers = {
+              Accept: 'application/vnd.github+json',
+              'User-Agent': 'meme-search-discord-release-workflow',
+            };
+
+            if (process.env.GITHUB_TOKEN) {
+              headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+            }
+
+            const response = await fetch(
+              `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+              { headers },
+            );
+
+            if (!response.ok) {
+              const responseBody = await response.text();
+              throw new Error(
+                `GitHub release lookup failed for ${tag} with ${response.status}: ${responseBody}`,
+              );
+            }
+
+            return response.json();
+          }
+
+          async function getRelease() {
+            if (!isManualRun) {
+              return event.release;
+            }
+
+            const tag = (inputs.tag || '').trim();
+            if (!tag) {
+              throw new Error('Manual runs require a release tag.');
+            }
+
+            return fetchReleaseByTag(tag);
+          }
+
+          function buildPayload(release) {
+            const releaseName = release.name || release.tag_name;
+            const body = (release.body || '').trim();
+            const maxDescriptionLength = 3500;
+            const description =
+              body.length > maxDescriptionLength
+                ? `${body.slice(0, maxDescriptionLength - 20).trimEnd()}...`
+                : body || 'Release notes are available on GitHub.';
+            const imageUrl = (inputs.image_url || '').trim();
+            const mentionUserId = (inputs.mention_user_id || '').trim();
+            const mentionText = mentionUserId ? `<@${mentionUserId}>` : '';
+            const content =
+              ((inputs.message || '').trim() || `Meme Search ${release.tag_name} is out.`).replaceAll(
+                '{mention}',
+                mentionText,
+              );
+
+            const embed = {
+              title: releaseName,
+              url: release.html_url,
+              description,
+              color: 0x238636,
+              fields: [
+                {
+                  name: 'Repository',
+                  value: repository,
+                  inline: true,
+                },
+                {
+                  name: 'Tag',
+                  value: `\`${release.tag_name}\``,
+                  inline: true,
+                },
+              ],
+              footer: {
+                text: `Published by ${release.author?.login || 'GitHub'}`,
+              },
+              timestamp: release.published_at,
+            };
+
+            if (imageUrl) {
+              embed.image = {
+                url: imageUrl,
+              };
+            }
+
+            return {
+              username: 'GitHub Releases',
+              allowed_mentions: {
+                parse: [],
+                users: mentionUserId ? [mentionUserId] : [],
+              },
+              content,
+              embeds: [embed],
+            };
+          }
+
+          function isDryRun() {
+            return String(inputs.dry_run || '').toLowerCase() === 'true';
+          }
+
+          async function main() {
+            const release = await getRelease();
+            const payload = buildPayload(release);
+
+            if (isDryRun()) {
+              console.log(JSON.stringify(payload, null, 2));
+              return;
+            }
+
+            if (!process.env.DISCORD_WEBHOOK_URL) {
+              console.log('DISCORD_RELEASE_WEBHOOK_URL is not set; skipping Discord notification.');
+              return;
+            }
+
+            const response = await fetch(process.env.DISCORD_WEBHOOK_URL, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+              const responseBody = await response.text();
+              throw new Error(
+                `Discord webhook failed with ${response.status}: ${responseBody}`,
+              );
+            }
+          }
+
+          main().catch((error) => {
+            console.error(error.message);
+            process.exit(1);
+          });
+          NODE


### PR DESCRIPTION
## Summary

Adds a Discord Release Notification workflow for Meme Search, modeled after the BugDrop release notifier.

The workflow can be manually dispatched with a release tag, optional custom message, optional embed image, optional allowlisted Discord mention, and a dry-run mode. It also supports `release.published` events for releases created outside the existing tag workflow.

## Validation

- Parsed `.github/workflows/discord-release.yml` with Ruby YAML loading.
- Ran the embedded Node script locally in `workflow_dispatch` dry-run mode against the real `v2.2.0` GitHub Release. It fetched `neonwatty/meme-search` release notes and produced the expected Discord payload with `content: "Meme Search v2.2.0 is out."`.

## Notes

- The workflow expects `DISCORD_RELEASE_WEBHOOK_URL` to be configured as a repository or organization Actions secret before non-dry-run posting.
- The existing tag-based release workflow creates GitHub Releases with Actions, so manual dispatch remains the reliable initial sharing path.
