### PR TITLE
Normalize generated descriptions before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Meme Search supports two providers for automatic meme descriptions:
 - `IMAGE_DESCRIPTION_PROVIDER=local` uses the bundled Python `image_to_text_generator` service. This is the default and keeps description generation local.
 - `IMAGE_DESCRIPTION_PROVIDER=openai` calls an OpenAI-compatible `/chat/completions` vision API directly from Rails. In this mode the Python generator service is not required.
 
-OpenAI-compatible descriptions are normalized to the app's description length limit before saving. Bulk generation queues durable Solid Queue background jobs for external providers so the web request does not wait on one API request per image.
+Descriptions from every provider are normalized to the app's description length limit before saving. Bulk generation queues durable Solid Queue background jobs for external providers so the web request does not wait on one API request per image.
 
 For OpenAI-compatible mode, set these environment variables in your `.env` file:
 

--- a/meme_search/meme_search_app/app/controllers/image_cores_controller.rb
+++ b/meme_search/meme_search_app/app/controllers/image_cores_controller.rb
@@ -43,13 +43,13 @@ class ImageCoresController < ApplicationController
     attempt = verified_callback_attempt
     return head :unauthorized unless attempt
 
-    description = callback_data[:description]
+    description = ImageCore.normalize_description(callback_data[:description])
 
     if attempt.succeed_with_description!(description)
       image_core = attempt.image_core.reload
       div_id = "description-image-core-id-#{image_core.id}"
       # update view with newly generated description
-      ActionCable.server.broadcast "image_description_channel", { div_id: div_id, description: description }
+      ActionCable.server.broadcast "image_description_channel", { div_id: div_id, description: image_core.description }
 
       # re-compute embeddings
       image_core.refresh_description_embeddings

--- a/meme_search/meme_search_app/app/models/image_core.rb
+++ b/meme_search/meme_search_app/app/models/image_core.rb
@@ -4,6 +4,8 @@ require "uri"
 
 
 class ImageCore < ApplicationRecord
+  DESCRIPTION_MAX_LENGTH = 500
+
   # keyword search scope
   include PgSearch::Model
   pg_search_scope :search_any_word,
@@ -36,7 +38,7 @@ class ImageCore < ApplicationRecord
 
   # validations
   validates_length_of :name, presence: true, minimum: 0, maximum: 100, allow_blank: false
-  validates_length_of :description, minimum: 0, maximum: 500, allow_blank: true
+  validates_length_of :description, minimum: 0, maximum: DESCRIPTION_MAX_LENGTH, allow_blank: true
   enum :status, [
     :not_started,
     :in_queue,
@@ -80,6 +82,10 @@ class ImageCore < ApplicationRecord
     return false unless attempt
 
     attempt.cancel!
+  end
+
+  def self.normalize_description(description)
+    description.to_s.squish.truncate(DESCRIPTION_MAX_LENGTH, separator: /\s/, omission: "")
   end
 
   def remove_image_text_job

--- a/meme_search/meme_search_app/app/models/image_description_generation_attempt.rb
+++ b/meme_search/meme_search_app/app/models/image_description_generation_attempt.rb
@@ -69,7 +69,7 @@ class ImageDescriptionGenerationAttempt < ApplicationRecord
 
   def succeed_with_description!(description)
     guarded_update do |attempt, image|
-      image.update!(description: description, status: :done)
+      image.update!(description: ImageCore.normalize_description(description), status: :done)
       attempt.update!(status: :succeeded, completed_at: Time.current)
     end
   end

--- a/meme_search/meme_search_app/app/services/image_description_providers/openai_provider.rb
+++ b/meme_search/meme_search_app/app/services/image_description_providers/openai_provider.rb
@@ -13,10 +13,6 @@ module ImageDescriptionProviders
     TEST_IMAGE_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAA+UlEQVR42u3aQQ7CIBCF4XcJz9K1R/DeXqdp0pUujYl0GBh5DC9hyeL/YqOVAftxTr0ggAACCCAANeB83mYCvHMtiw5g7I6QYFR6LwbGprczQFLvNoCn3mcAVb3DALb6WgMI66sM4Ky3G0BbbzQsABhYbzF0A2z3R1WWfX8TwJjyubrvLxuWB3zVXDbV7m8C2J/m6E+gYBAg/lvoT4BRvwYC0AKo6gsGPUICCCDAr1c0y4oFlA3uaAcm5HXal0IKcD/Z4YCF/tTzAnSwRQCY/mw0w+l0hvlAhglNhhlZhillhjlxhkl9krsSSW6r5LkvpCtnAgggwGqAFzX/iQwCblWQAAAAAElFTkSuQmCC"
     TEST_PROMPT = "Reply with ok if you can inspect this image."
     UNSUPPORTED_TEST_RESPONSE_MESSAGE = "OpenAI connection test returned an unsupported response."
-    MAX_DESCRIPTION_LENGTH = ImageCore.validators_on(:description)
-      .grep(ActiveModel::Validations::LengthValidator)
-      .filter_map { |validator| validator.options[:maximum] }
-      .min || 500
     MAX_COMPLETION_TOKENS = 160
 
     def initialize(configuration = Configuration.current)
@@ -92,7 +88,7 @@ module ImageDescriptionProviders
         return fail_image(image_core, attempt, "OpenAI API key is required. Add one in Settings or set OPENAI_API_KEY.")
       end
 
-      description = normalize_description(request_description(image_core))
+      description = ImageCore.normalize_description(request_description(image_core))
       if description.blank?
         return fail_image(image_core, attempt, "OpenAI vision API returned an unsupported response.")
       end
@@ -146,10 +142,6 @@ module ImageDescriptionProviders
             }
           ]
         }
-      end
-
-      def normalize_description(description)
-        description.to_s.squish.truncate(MAX_DESCRIPTION_LENGTH, omission: "")
       end
 
       def data_uri(image_core)

--- a/meme_search/meme_search_app/test/controllers/image_cores_controller_test.rb
+++ b/meme_search/meme_search_app/test/controllers/image_cores_controller_test.rb
@@ -568,6 +568,25 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal original_description, image_core.description
   end
 
+  test "description_receiver truncates long local descriptions before persistence" do
+    image_core = image_cores(:one)
+    attempt = local_attempt_for(image_core)
+    long_description = ([ "A detailed Florence caption with visible meme text" ] * 30).join(" ")
+
+    post description_receiver_image_cores_url, params: {
+      data: {
+        image_core_id: image_core.id,
+        description: long_description,
+        attempt_id: attempt.id,
+        callback_token: attempt.callback_token
+      }
+    }, as: :json
+
+    assert_response :success
+    assert_equal ImageCore.normalize_description(long_description), image_core.reload.description
+    assert_operator image_core.description.length, :<=, ImageCore::DESCRIPTION_MAX_LENGTH
+  end
+
   test "description_receiver should broadcast to image_description_channel" do
     image_core = image_cores(:one)
     description = "AI generated description"

--- a/meme_search/meme_search_app/test/models/image_description_generation_attempt_test.rb
+++ b/meme_search/meme_search_app/test/models/image_description_generation_attempt_test.rb
@@ -39,6 +39,20 @@ class ImageDescriptionGenerationAttemptTest < ActiveSupport::TestCase
     assert_equal "done", image_core.status
   end
 
+  test "successful attempt normalizes descriptions to the model limit" do
+    image_core = image_cores(:one)
+    attempt = image_core.start_description_generation_attempt!(provider: "local")
+    image_core.update!(status: :in_queue)
+    long_description = ([ "Florence generated a detailed caption" ] * 30).join(" ")
+
+    assert attempt.succeed_with_description!(long_description)
+
+    saved_description = image_core.reload.description
+    assert_operator saved_description.length, :<=, ImageCore::DESCRIPTION_MAX_LENGTH
+    assert_equal saved_description, ImageCore.normalize_description(long_description)
+    assert_equal "done", image_core.status
+  end
+
   test "cancel active attempt resets queued image to not started" do
     image_core = image_cores(:one)
     image_core.start_description_generation_attempt!(provider: "openai")


### PR DESCRIPTION
## Summary

Normalize descriptions from both local and external providers before they are persisted, keeping generated captions within the model's 500-character validation limit.

## Why

Florence can return captions longer than 500 characters. The callback previously attempted to save those verbatim, causing an HTTP 422 response and leaving generation incomplete.

## User impact

Long local captions now complete successfully and are stored at a word boundary within the existing description limit. External-provider generation uses the same normalization path.

## Verification

- `bundle exec rails test test/models/image_description_generation_attempt_test.rb test/controllers/image_cores_controller_test.rb`
- 58 runs, 135 assertions, 0 failures

Closes #166
