### PR TITLE
Delete meme source files from the web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ volumes:
 ...
 ```
 
+Read-only mounts can be indexed and searched, but the Delete action in the web UI cannot remove their source files. The UI reports a clear error and keeps the database record when the mount is not writable.
+
 Now restart the app, and register the `new_memes` via the UX by traversing to the `settings -> paths -> create new` as illustrated below.  Type in `new_memes` in the field provided and press `enter`.
 
 <img align="center" src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-add-new-memes.webp" height="225">

--- a/meme_search/meme_search_app/app/controllers/image_cores_controller.rb
+++ b/meme_search/meme_search_app/app/controllers/image_cores_controller.rb
@@ -365,12 +365,15 @@ class ImageCoresController < ApplicationController
 
   # DELETE /image_cores/1 or /image_cores/1.json
   def destroy
+    @image_core.delete_source_file!
     @image_core.destroy!
 
     respond_to do |format|
-      flash[:notice] = "Meme succesfully deleted!"
+      flash[:notice] = "Meme successfully deleted from the library and disk."
       format.html { redirect_to image_cores_path, status: :see_other }
     end
+  rescue ImageCore::FileDeletionError => e
+    redirect_to @image_core, alert: e.message, status: :see_other
   end
 
   private

--- a/meme_search/meme_search_app/app/models/image_core.rb
+++ b/meme_search/meme_search_app/app/models/image_core.rb
@@ -6,6 +6,8 @@ require "uri"
 class ImageCore < ApplicationRecord
   DESCRIPTION_MAX_LENGTH = 500
 
+  class FileDeletionError < StandardError; end
+
   # keyword search scope
   include PgSearch::Model
   pg_search_scope :search_any_word,
@@ -86,6 +88,33 @@ class ImageCore < ApplicationRecord
 
   def self.normalize_description(description)
     description.to_s.squish.truncate(DESCRIPTION_MAX_LENGTH, separator: /\s/, omission: "")
+  end
+
+  def source_file_path
+    memes_root = Rails.root.join("public", "memes").cleanpath
+    relative_path = Pathname.new(File.join(image_path.name.to_s, name.to_s)).cleanpath
+
+    if relative_path.absolute? || relative_path.each_filename.any? { |segment| segment == ".." }
+      raise FileDeletionError, "Refusing to access a file outside the configured meme library."
+    end
+
+    memes_root.join(relative_path).cleanpath
+  end
+
+  def delete_source_file!
+    path = source_file_path
+    return false unless path.exist?
+
+    unless path.file?
+      raise FileDeletionError, "The configured meme path is not a regular file."
+    end
+
+    path.delete
+    true
+  rescue Errno::EACCES, Errno::EPERM, Errno::EROFS => e
+    raise FileDeletionError, "The meme file could not be deleted. Check that the mounted directory is writable. (#{e.message})"
+  rescue SystemCallError => e
+    raise FileDeletionError, "The meme file could not be deleted. (#{e.message})"
   end
 
   def remove_image_text_job

--- a/meme_search/meme_search_app/app/views/image_cores/show.html.erb
+++ b/meme_search/meme_search_app/app/views/image_cores/show.html.erb
@@ -13,6 +13,8 @@
   <div class="flex flex-row space-x-4 mt-6">
     <%= link_to "Edit details", [:edit, @image_core], class: edit_button_classes %>
     <%= link_to "Back to memes", root_path, class: back_button_classes %>
-    <%= button_to "Delete", @image_core, method: :delete,  data: { confirm: 'Are you sure?' }, class: delete_button_classes %>
+    <%= button_to "Delete", @image_core, method: :delete,
+      data: { turbo_confirm: "Delete this meme from both the library and disk? This cannot be undone." },
+      class: delete_button_classes %>
   </div>
 </div>

--- a/meme_search/meme_search_app/test/controllers/image_cores_controller_test.rb
+++ b/meme_search/meme_search_app/test/controllers/image_cores_controller_test.rb
@@ -136,12 +136,13 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
 
   # Destroy action tests
   test "should destroy image_core" do
-    image_core = ImageCore.create!(
-      name: "to_delete.jpg",
-      description: "test",
-      status: :not_started,
-      image_path: @image_path
-    )
+    test_directory = Rails.root.join("public", "memes", "controller-delete-test")
+    FileUtils.mkdir_p(test_directory)
+    file_path = test_directory.join("to_delete.jpg")
+    File.binwrite(file_path, "test image contents")
+    image_path = ImagePath.create!(name: "controller-delete-test")
+    image_core = image_path.image_cores.find_by!(name: "to_delete.jpg")
+    image_core.update!(description: "test", status: :not_started)
 
     # Mock HTTP DELETE request to image-to-text service using Webmock
     stub_request(:delete, /\/remove_job\/#{image_core.id}/)
@@ -152,6 +153,30 @@ class ImageCoresControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to image_cores_url
+    assert_not file_path.exist?
+    assert_equal "Meme successfully deleted from the library and disk.", flash[:notice]
+  ensure
+    FileUtils.rm_rf(test_directory) if test_directory
+  end
+
+  test "destroy keeps the database record when the source file cannot be deleted" do
+    image_core = ImageCore.create!(
+      name: "protected.jpg",
+      description: "test",
+      status: :not_started,
+      image_path: @image_path
+    )
+
+    image_core.stub(:delete_source_file!, -> { raise ImageCore::FileDeletionError, "The meme file could not be deleted." }) do
+      ImageCore.stub(:find, image_core) do
+        assert_no_difference("ImageCore.count") do
+          delete image_core_url(image_core)
+        end
+      end
+    end
+
+    assert_redirected_to image_core_url(image_core)
+    assert_equal "The meme file could not be deleted.", flash[:alert]
   end
 
   # Search action tests

--- a/playwright/pages/image-cores.page.ts
+++ b/playwright/pages/image-cores.page.ts
@@ -60,6 +60,18 @@ export class ImageCoresPage {
   }
 
   /**
+   * Find a meme card by its image filename and return the ImageCore ID.
+   */
+  async getMemeIdByFilename(filename: string): Promise<number | null> {
+    const image = this.page.locator(`img[src*="${filename}"]`).first();
+    const card = image.locator('xpath=ancestor::div[starts-with(@id, "image_core_card_")]').first();
+    const id = await card.getAttribute('id');
+    const match = id?.match(/image_core_card_(\d+)/);
+
+    return match ? parseInt(match[1], 10) : null;
+  }
+
+  /**
    * Get count of tags displayed on the show page
    * Note: Glassmorphic UI displays tags as <span> elements with tag_detail_ prefix
    */

--- a/playwright/tests/image-cores.spec.ts
+++ b/playwright/tests/image-cores.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { ImageCoresPage } from '../pages/image-cores.page';
 import { resetTestDatabase } from '../utils/db-setup';
+import { addTestImage, fileExists, getMemeFilePath, removeTestImage } from '../utils/filesystem-helpers';
+
+const DELETE_TEST_FILENAME = 'playwright-delete-test.jpg';
 
 /**
  * Image Cores Tests
@@ -14,11 +17,17 @@ test.describe('Image Cores', () => {
 
   // Reset and seed database before each test
   test.beforeEach(async ({ page }) => {
+    await addTestImage('example_memes_1', DELETE_TEST_FILENAME);
+
     // Reset test database with fixture data
     await resetTestDatabase();
 
     // Initialize page object
     imageCoresPage = new ImageCoresPage(page);
+  });
+
+  test.afterEach(async () => {
+    await removeTestImage('example_memes_1', DELETE_TEST_FILENAME);
   });
 
   test('visiting the index - edit description and tags', async ({ page }) => {
@@ -94,18 +103,18 @@ test.describe('Image Cores', () => {
     console.log(`Initial meme count: ${firstMemeCount}`);
 
     // 2. Get first available meme ID and visit its show page
-    const firstMemeId = await imageCoresPage.getFirstMemeId();
+    const firstMemeId = await imageCoresPage.getMemeIdByFilename(DELETE_TEST_FILENAME);
     expect(firstMemeId).not.toBeNull();
-    console.log(`First meme ID: ${firstMemeId}`);
+    console.log(`Delete-test meme ID: ${firstMemeId}`);
 
     await imageCoresPage.gotoShow(firstMemeId!);
     console.log(`Navigated to meme show page: ${page.url()}`);
 
     // 3. Set up dialog handler BEFORE clicking delete
-    // The confirmation dialog asks "Are you sure?"
+    // The confirmation dialog explains that deletion affects the source file.
     page.once('dialog', async (dialog) => {
       console.log(`Dialog appeared: ${dialog.message()}`);
-      expect(dialog.message()).toContain('Are you sure?');
+      expect(dialog.message()).toContain('both the library and disk');
       await dialog.accept();
     });
 
@@ -115,7 +124,7 @@ test.describe('Image Cores', () => {
     console.log(`After delete, redirected to: ${page.url()}`);
 
     // 5. Verify success message appears
-    const hasSuccess = await imageCoresPage.hasSuccessMessage('Meme succesfully deleted!');
+    const hasSuccess = await imageCoresPage.hasSuccessMessage('Meme successfully deleted from the library and disk.');
     if (!hasSuccess) {
       console.log('Success message not visible (may have auto-dismissed)');
     }
@@ -125,5 +134,7 @@ test.describe('Image Cores', () => {
     const secondMemeCount = await imageCoresPage.getMemeCount();
     console.log(`Meme count after delete: ${secondMemeCount}`);
     expect(secondMemeCount).toBe(firstMemeCount - 1);
+
+    expect(fileExists(getMemeFilePath('example_memes_1', DELETE_TEST_FILENAME))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Make the explicit Delete action remove both the `ImageCore` record and its source image, while keeping directory-rescan cleanup record-only.

## Why

The UI previously deleted only the database record. Because the file remained on disk, the next directory scan recreated the meme.

## User impact

- Delete now clearly confirms that the operation affects disk.
- Writable source files are removed before the record is destroyed.
- Read-only or permission failures keep the record and show an actionable error.
- Rescans remain non-destructive to source files.

## Verification

- `bundle exec rails test test/controllers/image_cores_controller_test.rb`
- 52 runs, 116 assertions, 0 failures
- `npx playwright test playwright/tests/image-cores.spec.ts --grep "should destroy image core"`
- 1 browser test passed

Closes #167
