### PR TITLE
Harden local deployment and path handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# The web UI binds to localhost by default because Meme Search does not yet
+# include authentication. Use 0.0.0.0 only on a trusted network or behind an
+# authenticated reverse proxy.
+APP_BIND_ADDRESS=127.0.0.1
+APP_PORT=3000
+
+# Optional persistent storage locations. Relative defaults are used when these
+# are left commented out.
+# MEME_SEARCH_DB_PATH=./meme_search/db_data/meme-search-db
+# MEME_SEARCH_DIRECT_UPLOADS_PATH=./meme_search/direct-uploads
+# MEME_SEARCH_GENERATOR_DB_PATH=./meme_search/db_data/image_to_text_generator
+# MEME_SEARCH_MODELS_PATH=./meme_search/models
+
+# Description generation is local by default.
+IMAGE_DESCRIPTION_PROVIDER=local
+
+# Only required when IMAGE_DESCRIPTION_PROVIDER=openai.
+# Images selected for description generation are sent to this endpoint.
+# OPENAI_API_BASE_URL=https://api.openai.com/v1
+# OPENAI_API_KEY=
+# OPENAI_VISION_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -11,7 +11,19 @@ By default, processing from image-to-text extraction, to vector embedding, to se
   alt="meme-search-2.0-demo">
   </p>
   
-This repository contains code, a walkthrough notebook, and apps for indexing, searching, and easily retrieving your memes based on semantic search of their content and text.
+This repository contains the services and web app for indexing, searching, and retrieving your memes with semantic and keyword search.
+
+## Quick start
+
+```sh
+git clone https://github.com/neonwatty/meme-search.git
+cd meme-search
+docker compose up
+```
+
+Open <http://localhost:3000>, then drag, drop, or paste images on the upload page. The first local description generation downloads the selected model, so it takes longer than later generations.
+
+The web UI binds to `127.0.0.1` by default because Meme Search does not currently include authentication. To access it from another device on a trusted network, copy `.env.example` to `.env` and set `APP_BIND_ADDRESS=0.0.0.0`. Do not expose an unauthenticated instance directly to the internet; use an authenticated reverse proxy or VPN.
 
 A table of contents for the remainder of this README:
 
@@ -22,7 +34,7 @@ A table of contents for the remainder of this README:
   - [Installation instructions](#installation-instructions)
   - [Time to first generation / downloading models](#time-to-first-generation--downloading-models)
   - [Index your memes](#index-your-memes)
-  - [Custom app port](#custom-app-port)
+  - [Custom bind address and app port](#custom-bind-address-and-app-port)
   - [Building the app locally with Docker](#building-the-app-locally-with-docker)
   - [Running tests](#running-tests)
 - [Discord server](#discord-server)
@@ -150,13 +162,13 @@ We recommend using [mise](https://mise.jdx.dev/) for managing Ruby, Python, and 
 
 ### Installation instructions
 
-To start up the app pull this repository and start the server cluster with docker-compose
+From the repository root, start the server cluster with Docker Compose:
 
 ```sh
 docker compose up
 ```
 
-This pulls and starts containers for the app, database, Solid Queue job worker, and local auto description generator. The app itself will run on port `3000` and is available at
+This pulls and starts containers for the app, database, Solid Queue job worker, and local auto description generator. The app runs on port `3000` and is available locally at:
 
 ```sh
 http://localhost:3000
@@ -217,6 +229,8 @@ Meme Search supports two providers for automatic meme descriptions:
 - `IMAGE_DESCRIPTION_PROVIDER=openai` calls an OpenAI-compatible `/chat/completions` vision API directly from Rails. In this mode the Python generator service is not required.
 
 Descriptions from every provider are normalized to the app's description length limit before saving. Bulk generation queues durable Solid Queue background jobs for external providers so the web request does not wait on one API request per image.
+
+When an external provider is selected, images chosen for description generation are sent to the configured API endpoint. Embeddings, metadata, and search remain local.
 
 For OpenAI-compatible mode, set these environment variables in your `.env` file:
 
@@ -296,14 +310,15 @@ Once registered in the app, your memes are ready for indexing / tagging / etc.,!
 
 The image-to-text models used to auto generate descriptions for your memes are all open source, and vary in size.
 
-### Custom app port
+### Custom bind address and app port
 
 Easily customize the app's port to more easily use the it with tools like [Unraid](https://unraid.net/?srsltid=AfmBOorvWvSZbCHKnqdR__AcllotnsLR6did_FhAaNfUowqqU2IprD1v) or [Portainer](https://www.portainer.io/), or because you already have services running on the default `meme_search` app port `3000`.
 
-To customize the main app port create a `.env` file locally in the root of the directory. In this file you can define the following custom environment variables which define how the app, image to text generator, and database are accessed. These values are:
+To customize the bind address or main app port, copy `.env.example` to `.env` in the repository root and adjust:
 
 ```sh
-APP_PORT= # the port for the app - defaults to 3000
+APP_BIND_ADDRESS=127.0.0.1 # use 0.0.0.0 only on a trusted network
+APP_PORT=3000
 ```
 
 This value is automatically detected and loaded into each service via the Compose files. The Postgres service is only exposed on Docker's internal network, so app containers always talk to it at `meme-search-db:5432`.

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -20,7 +20,7 @@ services:
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       OPENAI_VISION_MODEL: "${OPENAI_VISION_MODEL:-}"
     ports:
-      - "${APP_PORT:-3000}:3000" # <--  adjust to desired local port for this service in your .env file
+      - "${APP_BIND_ADDRESS:-127.0.0.1}:${APP_PORT:-3000}:3000" # Set APP_BIND_ADDRESS=0.0.0.0 only for trusted networks.
     depends_on:
       meme_search_uploads_setup:
         condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       OPENAI_VISION_MODEL: "${OPENAI_VISION_MODEL:-}"
     ports:
-      - "${APP_PORT:-3000}:3000" # <--  adjust to desired local port for this service in your .env file
+      - "${APP_BIND_ADDRESS:-127.0.0.1}:${APP_PORT:-3000}:3000" # Set APP_BIND_ADDRESS=0.0.0.0 only for trusted networks.
     depends_on:
       meme_search_uploads_setup:
         condition: service_completed_successfully

--- a/meme_search/meme_search_app/app/models/image_path.rb
+++ b/meme_search/meme_search_app/app/models/image_path.rb
@@ -32,8 +32,7 @@ class ImagePath < ApplicationRecord
 
     if direct_uploads_path.new_record?
       # Create the directory if it doesn't exist
-      base_dir = Dir.getwd
-      full_path = File.join(base_dir, "public", "memes", "direct-uploads")
+      full_path = Rails.root.join("public", "memes", "direct-uploads")
       FileUtils.mkdir_p(full_path) unless File.directory?(full_path)
 
       # Save with manual scan only (no auto-scan)
@@ -65,6 +64,16 @@ class ImagePath < ApplicationRecord
     return "Manual only" unless auto_scan_enabled?
     return "Due now" if due_for_scan?
     distance_of_time_in_words(Time.current, next_scan_time, include_seconds: false)
+  end
+
+  def directory_path
+    relative_path = Pathname.new(name.to_s).cleanpath
+    segments = relative_path.each_filename.to_a
+
+    return if relative_path.absolute?
+    return if segments.empty? || segments.any? { |segment| segment == ".." }
+
+    Rails.root.join("public", "memes", *segments).cleanpath
   end
 
   def scan_and_update!
@@ -105,10 +114,8 @@ class ImagePath < ApplicationRecord
     def valid_dir
       return if self.name.blank?
 
-      base_dir = Dir.getwd
-      full_path = base_dir + "/public/memes/" + self.name
-      puts full_path
-      unless File.directory?(full_path)
+      full_path = directory_path
+      unless full_path&.directory?
         self.errors.add :name, message: "The input path - #{self.name} - is not a valid subdirectory in /public/memes"
       end
     end
@@ -117,12 +124,11 @@ class ImagePath < ApplicationRecord
     end
 
   def list_files_in_directory
-    base_dir = Dir.getwd
-    full_path = base_dir + "/public/memes/" + self.name
+    full_path = directory_path
 
     # Return early if directory doesn't exist
-    unless File.directory?(full_path)
-      puts "Directory does not exist."
+    unless full_path&.directory?
+      Rails.logger.warn "[Scan] Refusing invalid or missing meme directory: #{name.inspect}"
       return { added: 0, removed: 0 }
     end
 

--- a/meme_search/meme_search_app/app/views/pages/about.html.erb
+++ b/meme_search/meme_search_app/app/views/pages/about.html.erb
@@ -46,7 +46,7 @@
       </section>
 
       <section class="text-sm text-slate-500 dark:text-slate-400 text-center pt-6 border-t border-gray-200 dark:border-gray-700">
-        <p>Meme Search is open source and self-hosted. No data leaves your server.</p>
+        <p>Meme Search is open source and self-hosted. Processing stays local when the local provider is selected; external providers receive the images you ask them to describe.</p>
         <p class="mt-2">
           <a href="https://github.com/neonwatty/meme-search"
              target="_blank"

--- a/meme_search/meme_search_app/test/controllers/settings/image_paths_controller_test.rb
+++ b/meme_search/meme_search_app/test/controllers/settings/image_paths_controller_test.rb
@@ -64,6 +64,28 @@ module Settings
       assert_equal "Invalid directory path!", flash[:alert]
     end
 
+    test "should reject paths that escape the meme library" do
+      assert_no_difference("ImagePath.count") do
+        post settings_image_paths_url, params: {
+          image_path: { name: "../" }
+        }
+      end
+
+      assert_response :unprocessable_entity
+      assert_equal "Invalid directory path!", flash[:alert]
+    end
+
+    test "should reject absolute directory paths" do
+      assert_no_difference("ImagePath.count") do
+        post settings_image_paths_url, params: {
+          image_path: { name: Rails.root.to_s }
+        }
+      end
+
+      assert_response :unprocessable_entity
+      assert_equal "Invalid directory path!", flash[:alert]
+    end
+
     test "should not create duplicate image_path" do
       # @image_path.name is "example_memes_1" from fixtures (already in DB)
       # The directory also exists on the filesystem
@@ -204,8 +226,8 @@ module Settings
             original_file_method.call(path)
           end
         } do
-          File.stub :join, ->(dir, file) {
-            original_join_method.call(dir, file)
+          File.stub :join, ->(*parts) {
+            original_join_method.call(*parts)
           } do
             post rescan_settings_image_path_url(image_path)
           end
@@ -342,8 +364,8 @@ module Settings
             original_file_method.call(path)
           end
         } do
-          File.stub :join, ->(dir, file) {
-            original_join_method.call(dir, file)
+          File.stub :join, ->(*parts) {
+            original_join_method.call(*parts)
           } do
             post rescan_settings_image_path_url(image_path)
           end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "meme-search",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meme-search",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.56.1",
         "@types/node": "^24.10.0",
-        "axios": "^1.13.1",
+        "axios": "^1.18.1",
         "dotenv": "^17.2.3",
         "typescript": "^5.9.3"
       }
@@ -42,6 +42,19 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -50,15 +63,16 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -86,6 +100,24 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/delayed-stream": {
@@ -147,9 +179,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -176,9 +208,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -197,17 +229,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -320,9 +352,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -330,6 +362,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/math-intrinsics": {
@@ -365,6 +411,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/playwright": {
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
@@ -398,11 +451,14 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@playwright/test": "^1.56.1",
     "@types/node": "^24.10.0",
-    "axios": "^1.13.1",
+    "axios": "^1.18.1",
     "dotenv": "^17.2.3",
     "typescript": "^5.9.3"
   }

--- a/scripts/test_compose_persistence_paths.sh
+++ b/scripts/test_compose_persistence_paths.sh
@@ -57,6 +57,7 @@ validate_compose_file() {
     assert_contains "$rendered_config" "meme_search/direct-uploads"
     assert_contains "$rendered_config" "meme_search/db_data/image_to_text_generator"
     assert_contains "$rendered_config" "meme_search/models"
+    assert_contains "$rendered_config" "host_ip: 127.0.0.1"
 }
 
 validate_path_overrides() {
@@ -80,6 +81,20 @@ validate_path_overrides() {
     assert_contains "$rendered_config" "source: /volume1/docker/meme-search/models"
 }
 
+validate_bind_address_override() {
+    local compose_file="$1"
+    local rendered_config
+    rendered_config="$(mktemp)"
+    trap 'rm -f "$rendered_config"' RETURN
+
+    (
+        cd "$ROOT_DIR"
+        APP_BIND_ADDRESS=0.0.0.0 docker compose -f "$compose_file" config > "$rendered_config"
+    )
+
+    assert_contains "$rendered_config" "host_ip: 0.0.0.0"
+}
+
 assert_directory_exists "meme_search/direct-uploads"
 assert_directory_exists "meme_search/db_data/image_to_text_generator"
 assert_directory_exists "meme_search/models"
@@ -92,5 +107,7 @@ validate_compose_file "docker-compose.yml"
 validate_compose_file "docker-compose-local-build.yml"
 validate_path_overrides "docker-compose.yml"
 validate_path_overrides "docker-compose-local-build.yml"
+validate_bind_address_override "docker-compose.yml"
+validate_bind_address_override "docker-compose-local-build.yml"
 
 echo "✓ Docker Compose persistence path tests passed"

--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,7 @@
   <meta property="og:image" content="https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Meme Search - AI-powered meme search engine you can self-host">
-  <meta name="twitter:description" content="Index your memes by content and text using local AI models. Free, open source, runs entirely on your machine.">
+  <meta name="twitter:description" content="Index your memes by content and text using local AI by default, with optional OpenAI-compatible vision providers.">
   <meta name="twitter:image" content="https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5">
   <title>Meme Search - AI-powered meme search engine you can self-host</title>
   <link rel="stylesheet" href="styles.css">
@@ -40,7 +40,7 @@
         <p class="eyebrow">Open source meme search engine</p>
         <h1>Find any meme by what's in it.</h1>
         <p class="lede">
-          Meme Search uses AI to index your memes by their content and text, making them instantly retrievable with semantic search. All processing runs locally on your machine.
+          Meme Search uses AI to index your memes by their content and text, making them instantly retrievable with semantic search. Processing is local by default, with an optional OpenAI-compatible vision provider.
         </p>
         <div class="actions" aria-label="Primary actions">
           <a class="button primary" href="https://github.com/neonwatty/meme-search#installation-instructions">Get started</a>
@@ -49,7 +49,7 @@
         <div class="badge-row">
           <img src="https://img.shields.io/github/stars/neonwatty/meme-search?style=flat" alt="GitHub stars">
           <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker ready">
-          <img src="https://img.shields.io/badge/100%25-local_AI-7c3aed" alt="100% local AI">
+          <img src="https://img.shields.io/badge/local_AI-default-7c3aed" alt="Local AI by default">
           <img src="https://img.shields.io/badge/Discord-Join%20Server-7289da?logo=discord&logoColor=white" alt="Discord">
         </div>
       </div>
@@ -251,7 +251,9 @@ docker compose up
   </main>
 
   <footer class="site-footer">
-    <span>Meme Search is MIT licensed.</span>
+    <span>Meme Search is Apache-2.0 licensed.</span>
+    <a href="https://neonwatty.com/">Built by Jeremy Watt</a>
+    <a href="https://neonwatty.com/projects/">More projects</a>
     <a href="https://discord.gg/7xsxU4ZG6A">Discord</a>
     <a href="https://github.com/neonwatty/meme-search/blob/main/CHANGELOG.md">Changelog</a>
     <a href="https://github.com/neonwatty/meme-search">GitHub</a>


### PR DESCRIPTION
## Summary

Harden the default self-hosted deployment and clarify its security and privacy boundaries.

## What changed

- Bind the web UI to `127.0.0.1` by default, with an explicit trusted-network override.
- Reject absolute image paths and paths that escape `public/memes`.
- Add a documented `.env.example`.
- Correct local-versus-external provider privacy wording and Apache-2.0 landing-page messaging.
- Link the landing page back to the maintainer portfolio.
- Update the Playwright Axios dependency; npm audit is clean.

## User impact

Existing same-host access at `http://localhost:3000` is unchanged. Users who intentionally need LAN access can set `APP_BIND_ADDRESS=0.0.0.0` and are warned to use a trusted network, authenticated proxy, or VPN.

## Verification

- Image-path controller tests: 30 runs, 92 assertions, 0 failures
- RuboCop: 104 files, no offenses
- Brakeman: 0 warnings
- Importmap audit: clean
- `npm audit`: 0 vulnerabilities
- `npx tsc --noEmit`
- Compose persistence and database URL tests
