### PR TITLE
Verify container provenance before releases

### DIFF
--- a/.github/workflows/pro-app-build.yml
+++ b/.github/workflows/pro-app-build.yml
@@ -1,6 +1,6 @@
 # Manual-only Docker build workflow for Rails application
 # Automated builds disabled - use workflow_dispatch for manual runs or scripts/build_and_push.sh for local builds
-name: "pro app build"
+name: "Build Rails container"
 on:
   workflow_dispatch:
 
@@ -81,6 +81,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/neonwatty/meme_search:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/pro-image-to-text-build.yml
+++ b/.github/workflows/pro-image-to-text-build.yml
@@ -1,6 +1,6 @@
 # Manual-only Docker build workflow for Python image-to-text service
 # Automated builds disabled - use workflow_dispatch for manual runs or scripts/build_and_push.sh for local builds
-name: "pro image to text build"
+name: "Build image-to-text container"
 on:
   workflow_dispatch:
 
@@ -99,6 +99,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/neonwatty/image_to_text_generator:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 # Release workflow - triggers on version tags
-# Creates versioned GHCR image tags from the refreshed latest manifests and publishes a GitHub release.
+# Verifies the refreshed latest images were built from the release commit,
+# creates versioned GHCR tags, and publishes a GitHub release.
 name: "Release"
 
 on:
@@ -47,6 +48,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify latest images were built from this commit
+        run: |
+          EXPECTED_REVISION="$(git rev-parse HEAD)"
+
+          docker pull --platform linux/amd64 ghcr.io/neonwatty/meme_search:latest
+          APP_REVISION="$(docker image inspect ghcr.io/neonwatty/meme_search:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+
+          docker pull --platform linux/amd64 ghcr.io/neonwatty/image_to_text_generator:latest
+          GENERATOR_REVISION="$(docker image inspect ghcr.io/neonwatty/image_to_text_generator:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+
+          if [ "$APP_REVISION" != "$EXPECTED_REVISION" ]; then
+            echo "Rails image revision $APP_REVISION does not match release commit $EXPECTED_REVISION"
+            exit 1
+          fi
+
+          if [ "$GENERATOR_REVISION" != "$EXPECTED_REVISION" ]; then
+            echo "Generator image revision $GENERATOR_REVISION does not match release commit $EXPECTED_REVISION"
+            exit 1
+          fi
+
       - name: Create versioned Docker image tags
         run: |
           docker buildx imagetools create \
@@ -63,26 +84,5 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
-          body: |
-            ## Highlights
-
-            - Added clipboard image paste support on the upload screen, including validation, generated filenames, and end-to-end coverage.
-            - Normalized image inputs before captioning so transparent, palette, and grayscale images are converted consistently for the vision model.
-            - Fixed Docker Compose database URLs when a custom host `DB_PORT` is set.
-            - Hardened Compose persistence paths for uploads, SQLite data, models, and generator-side storage.
-            - Refreshed the multi-arch Docker images for AMD64 and ARM64.
-
-            ## Contributor Thanks
-
-            Thanks to the issue reporters and reviewers who helped pin down the upload, captioning, and Docker Compose edge cases covered by this release.
-
-            ## Docker Images
-
-            Multi-arch images are available for Linux AMD64 and ARM64:
-
-            - `ghcr.io/neonwatty/meme_search:v${{ steps.get_version.outputs.version }}`
-            - `ghcr.io/neonwatty/image_to_text_generator:v${{ steps.get_version.outputs.version }}`
-
-            The `latest` tags have also been refreshed.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -325,7 +325,9 @@ This value is automatically detected and loaded into each service via the Compos
 
 ### Building the app locally with Docker
 
-**Docker images are built manually only** - there are no automated CI builds on releases or tags.
+Docker images are built manually before a release because multi-platform model builds are resource intensive. The release workflow verifies both `latest` images carry the exact release commit revision before it creates versioned tags, preventing a Git tag from pointing at images built from different source.
+
+Maintainers should follow the [`RELEASING.md`](RELEASING.md) checklist.
 
 To build the app - including all services defined in the `docker-compose.yml` file - locally run the local compose file at your terminal as
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,26 @@
+# Releasing Meme Search
+
+Meme Search publishes two multi-platform images and a GitHub release. Version tags must use the `vX.Y.Z` format.
+
+## Release checklist
+
+1. Merge the intended release changes and update `VERSION` to `X.Y.Z`.
+2. Record the release commit SHA and avoid merging additional commits until the images and tag are published.
+3. Run both manual workflows against that same ref:
+   - **Build Rails container**
+   - **Build image-to-text container**
+4. Confirm both workflows succeed. They publish multi-platform `latest` images with source-revision labels, SBOMs, and provenance attestations.
+5. Tag the recorded commit and push the tag:
+
+   ```sh
+   git tag -a vX.Y.Z RELEASE_COMMIT_SHA -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+6. The Release workflow verifies that:
+   - the tag matches `VERSION`;
+   - both `latest` images were built from the tagged commit; and
+   - versioned image tags can be created from those manifests.
+7. Confirm the generated GitHub release and both versioned GHCR tags are visible.
+
+If either image revision does not match the tag, the release fails before publishing. Rebuild both images from the release commit, then rerun the failed workflow.


### PR DESCRIPTION
## Summary

Make versioned releases fail closed unless both published `latest` container images were built from the exact tagged commit.

## What changed

- Add OCI metadata labels to both manual image builds.
- Publish BuildKit provenance attestations and SBOMs.
- Inspect each image's source revision before creating version tags.
- Replace stale hard-coded release copy with generated release notes.
- Add a maintainer release checklist documenting the required build-then-tag sequence.

## Maintainer impact

For the first release after this merges, both manual container build workflows must run from the intended release commit before the version tag is pushed. A mismatched or stale image now stops the release before publication.

## Verification

- Parsed all GitHub Actions workflow YAML successfully.
- `git diff --check`
