### PR TITLE
Update Brakeman to 8.0.5

### DIFF
--- a/meme_search/meme_search_app/Gemfile
+++ b/meme_search/meme_search_app/Gemfile
@@ -42,7 +42,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", "8.0.4", require: false
+  gem "brakeman", "8.0.5", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/meme_search/meme_search_app/Gemfile.lock
+++ b/meme_search/meme_search_app/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     concurrent-ruby (1.3.5)
@@ -373,7 +373,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman (= 8.0.4)
+  brakeman (= 8.0.5)
   debug
   image_processing (~> 1.2)
   importmap-rails


### PR DESCRIPTION
## Summary

Update the pinned Brakeman dependency from 8.0.4 to 8.0.5.

## Why

The repository's Ruby security-check job runs Brakeman with its update enforcement enabled. Brakeman 8.0.4 now exits with code 5 because 8.0.5 is available, causing the same unrelated CI failure on PRs #169–#173.

## Impact

This restores the shared Ruby security check without changing application behavior. After this merges, the five hardening PRs can be refreshed against the corrected baseline.

## Verification

- `bundle check`
- `bin/brakeman -w3 --no-pager`
- Brakeman 8.0.5: 79 checks, 0 warnings

Prerequisite for #169, #170, #171, #172, and #173.
