### PR TITLE
Add CI coverage for root npm updates

### DIFF
--- a/.github/workflows/pro-app-test.yml
+++ b/.github/workflows/pro-app-test.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
     branches: ["main", "develop"]
     paths:
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "playwright.config.ts"
+      - "playwright/**"
+      - "playwright-docker/**"
       - "meme_search/meme_search_app/**"
       - ".github/workflows/pro-app-test.yml"
       - "README.md"
@@ -14,6 +20,12 @@ on:
   push:
     branches: ["main", "develop"]
     paths:
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "playwright.config.ts"
+      - "playwright/**"
+      - "playwright-docker/**"
       - "meme_search/meme_search_app/**"
       - ".github/workflows/pro-app-test.yml"
       - "README.md"
@@ -200,6 +212,12 @@ jobs:
 
       - name: Install Node.js dependencies
         run: npm ci
+
+      - name: Audit Node.js dependencies
+        run: npm audit --audit-level=high
+
+      - name: Type-check Playwright tests
+        run: npx tsc --noEmit
 
       - name: Cache Playwright browsers
         id: playwright-cache


### PR DESCRIPTION
## What changed

- Run the Rails/Playwright workflow when root npm, TypeScript, or Playwright files change.
- Audit root Node dependencies at high severity.
- Type-check Playwright tests before running the browser suite.

## Why

Dependabot PRs that only modify root `package.json` and `package-lock.json` currently receive no GitHub Actions checks, leaving Playwright and TypeScript upgrades without repository CI coverage.

## Validation

- `npm ci`
- `npm audit --audit-level=high`
- `npx tsc --noEmit`
- `CI=1 npx playwright test --list` (66 tests discovered)
- workflow YAML parse
- `git diff --check`