### PR TITLE
Finish landing page technical SEO foundation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,10 +6,14 @@ on:
       - main
     paths:
       - "site/**"
+      - "scripts/validate_site.mjs"
+      - "package.json"
       - ".github/workflows/pages.yml"
   pull_request:
     paths:
       - "site/**"
+      - "scripts/validate_site.mjs"
+      - "package.json"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -26,7 +30,17 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+      - run: npm run test:site
+
   deploy:
+    needs: validate
     if: github.event_name != 'pull_request'
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Use AI to index your memes by their content and text, making them easily retriev
 
 By default, processing from image-to-text extraction, to vector embedding, to search is performed locally. You can also use an OpenAI-compatible vision API for description generation while keeping embeddings and search local.
 
+Visit the [Meme Search project site](https://neonwatty.github.io/meme-search/) for a visual feature overview, or continue below for installation and configuration details.
+
   <p align="center">
     <img src="https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5"
   alt="meme-search-2.0-demo">

--- a/docs/technical-seo-content-plan.md
+++ b/docs/technical-seo-content-plan.md
@@ -1,0 +1,22 @@
+# Technical SEO content plan
+
+The GitHub Pages site intentionally remains a focused, single-page project overview. The following supporting pages are candidates only when there is enough original material to answer a distinct search intent; thin copies of README sections should not be published.
+
+## Priorities
+
+1. **Local AI meme search guide** — Explain the indexing pipeline, semantic versus keyword search, privacy boundaries, and the path from an image to a result. Link to the relevant source modules for readers who want implementation detail.
+2. **Vision model comparison** — Compare the supported Florence-2, SmolVLM, and Moondream variants using maintained hardware requirements, expected tradeoffs, and a reproducible selection rubric. Keep model facts synchronized with the application and README.
+3. **Security and privacy architecture** — Document what stays local, what leaves the host when an optional OpenAI-compatible provider is enabled, and safe patterns for remote access. Link to `SECURITY.md` and the configuration reference.
+4. **Release highlights** — Add a durable, user-oriented release index only if it can be generated or routinely maintained from release notes without duplicating the changelog.
+
+## Guardrails
+
+- Do not create NAS-specific deployment content here; that belongs to the separate NAS initiative.
+- Do not create translated or Chinese-language documentation here; that belongs to the separate localization initiative.
+- Every published page must have a unique title, description, canonical URL, social metadata, and a sitemap entry using the `/meme-search/` base path.
+- Add reciprocal, descriptive links between the landing page and each supporting page.
+- Publish only content with a named maintainer or a reliable synchronization check; stale model and deployment details are worse than a smaller site.
+
+## GitHub Pages deployment note
+
+This project repository publishes `site/robots.txt` at `/meme-search/robots.txt`, which resolves the project-path 404 and advertises the project sitemap. The Robots Exclusion Protocol discovers robots rules only at the origin-level `/robots.txt`; that URL is controlled by the separate `neonwatty.github.io` user-site repository. If origin-level sitemap discovery is required, add the sitemap directive there as a separate infrastructure change. The landing page also carries explicit page-level indexing directives.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:ci:verbose": "bash scripts/run_all_ci_tests.sh --verbose",
     "test:rails": "bash scripts/run_all_ci_tests.sh --skip-python --skip-e2e",
     "test:python": "bash scripts/run_all_ci_tests.sh --skip-rails --skip-e2e",
+    "test:site": "node scripts/validate_site.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/scripts/validate_site.mjs
+++ b/scripts/validate_site.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+import { readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const siteRoot = join(repositoryRoot, "site");
+const baseUrl = "https://neonwatty.github.io/meme-search/";
+const repositoryUrl = "https://github.com/neonwatty/meme-search";
+const expectedTitle = "Meme Search - AI-powered meme search engine you can self-host";
+const expectedDescription =
+  "Open source meme search engine that uses local AI to index images by content and text for semantic search. Self-host with Docker.";
+const expectedImage =
+  "https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5";
+const errors = [];
+
+function check(condition, message) {
+  if (!condition) errors.push(message);
+}
+
+function readSiteFile(fileName) {
+  try {
+    return readFileSync(join(siteRoot, fileName), "utf8");
+  } catch (error) {
+    errors.push(`Unable to read site/${fileName}: ${error.message}`);
+    return "";
+  }
+}
+
+function parseAttributes(source) {
+  const attributes = {};
+  const pattern = /([:@\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+  for (const match of source.matchAll(pattern)) {
+    attributes[match[1].toLowerCase()] = match[2] ?? match[3];
+  }
+  return attributes;
+}
+
+function elements(html, tagName) {
+  const pattern = new RegExp(`<${tagName}\\b([^>]*)>`, "gi");
+  return [...html.matchAll(pattern)].map((match) => ({
+    source: match[0],
+    attributes: parseAttributes(match[1]),
+  }));
+}
+
+function oneElement(elementsToCheck, description) {
+  check(elementsToCheck.length === 1, `Expected one ${description}, found ${elementsToCheck.length}`);
+  return elementsToCheck[0];
+}
+
+function metaContent(html, attributeName, attributeValue) {
+  const matches = elements(html, "meta").filter(
+    ({ attributes }) => attributes[attributeName] === attributeValue,
+  );
+  const element = oneElement(matches, `${attributeName}="${attributeValue}" meta tag`);
+  return element?.attributes.content;
+}
+
+function linkHref(html, relation) {
+  const matches = elements(html, "link").filter(({ attributes }) =>
+    (attributes.rel ?? "").split(/\s+/).includes(relation),
+  );
+  const element = oneElement(matches, `rel="${relation}" link`);
+  return element?.attributes.href;
+}
+
+function validateBalancedHtml(html) {
+  const voidElements = new Set([
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+  ]);
+  const stack = [];
+  const withoutComments = html.replace(/<!--[\s\S]*?-->/g, "");
+  const pattern = /<\/?([a-z][\w-]*)\b[^>]*>/gi;
+
+  for (const match of withoutComments.matchAll(pattern)) {
+    const tag = match[1].toLowerCase();
+    const isClosing = match[0].startsWith("</");
+    const isSelfClosing = match[0].endsWith("/>");
+
+    if (isClosing) {
+      const expected = stack.pop();
+      check(expected === tag, `HTML nesting error: expected </${expected ?? "none"}>, found </${tag}>`);
+    } else if (!voidElements.has(tag) && !isSelfClosing) {
+      stack.push(tag);
+    }
+  }
+
+  check(stack.length === 0, `Unclosed HTML elements: ${stack.join(", ")}`);
+}
+
+function siteFileForUrl(urlString) {
+  const url = new URL(urlString, baseUrl);
+  const base = new URL(baseUrl);
+
+  if (url.origin !== base.origin) return null;
+  if (!url.pathname.startsWith(base.pathname)) {
+    errors.push(`Same-origin URL escapes the GitHub Pages base path: ${urlString}`);
+    return null;
+  }
+
+  let pathWithinSite = decodeURIComponent(url.pathname.slice(base.pathname.length));
+  if (!pathWithinSite || pathWithinSite.endsWith("/")) pathWithinSite += "index.html";
+
+  const absolutePath = resolve(siteRoot, pathWithinSite);
+  const relativePath = relative(siteRoot, absolutePath);
+  if (relativePath.startsWith(`..${sep}`) || relativePath === "..") {
+    errors.push(`URL resolves outside site/: ${urlString}`);
+    return null;
+  }
+
+  return absolutePath;
+}
+
+function validateLocalUrl(urlString, context) {
+  if (
+    !urlString ||
+    urlString.startsWith("#") ||
+    urlString.startsWith("mailto:") ||
+    urlString.startsWith("tel:")
+  ) {
+    return;
+  }
+
+  let absolutePath;
+  try {
+    absolutePath = siteFileForUrl(urlString);
+  } catch {
+    errors.push(`Invalid URL in ${context}: ${urlString}`);
+    return;
+  }
+
+  if (!absolutePath) return;
+  try {
+    check(statSync(absolutePath).isFile(), `${context} points to a non-file: ${urlString}`);
+  } catch {
+    errors.push(`${context} points to a missing local file: ${urlString}`);
+  }
+}
+
+function validateJsonLd(html) {
+  const scripts = elements(html, "script").filter(
+    ({ attributes }) => attributes.type === "application/ld+json",
+  );
+  check(scripts.length > 0, "At least one JSON-LD script is required");
+
+  const documents = [];
+  const scriptPattern =
+    /<script\b[^>]*type=(?:"application\/ld\+json"|'application\/ld\+json')[^>]*>([\s\S]*?)<\/script>/gi;
+  for (const [index, match] of [...html.matchAll(scriptPattern)].entries()) {
+    try {
+      documents.push(JSON.parse(match[1]));
+    } catch (error) {
+      errors.push(`JSON-LD block ${index + 1} is invalid JSON: ${error.message}`);
+    }
+  }
+
+  const nodes = documents.flatMap((document) => document["@graph"] ?? [document]);
+  const website = nodes.find((node) => node["@type"] === "WebSite");
+  const application = nodes.find((node) => node["@type"] === "SoftwareApplication");
+  const sourceCode = nodes.find((node) => node["@type"] === "SoftwareSourceCode");
+
+  check(documents.every((document) => document["@context"] === "https://schema.org"), "JSON-LD must use the schema.org context");
+  check(Boolean(website), "JSON-LD must describe the WebSite");
+  check(Boolean(application), "JSON-LD must describe a SoftwareApplication");
+  check(Boolean(sourceCode), "JSON-LD must describe the SoftwareSourceCode");
+
+  if (website) {
+    check(website.url === baseUrl, "WebSite JSON-LD URL must match the canonical URL");
+    check(website.description === expectedDescription, "WebSite JSON-LD description must match page metadata");
+    check(website.mainEntity?.["@id"] === application?.["@id"], "WebSite mainEntity must reference the SoftwareApplication");
+  }
+
+  if (application) {
+    const requiredApplicationFields = [
+      "name",
+      "url",
+      "description",
+      "applicationCategory",
+      "operatingSystem",
+      "isAccessibleForFree",
+      "license",
+      "image",
+      "featureList",
+      "softwareRequirements",
+    ];
+    for (const field of requiredApplicationFields) {
+      check(application[field] !== undefined, `SoftwareApplication JSON-LD is missing ${field}`);
+    }
+    check(application.url === baseUrl, "SoftwareApplication URL must match the canonical URL");
+    check(application.description === expectedDescription, "SoftwareApplication description must match page metadata");
+    check(application.image === expectedImage, "SoftwareApplication image must match social metadata");
+    check(application.isAccessibleForFree === true, "SoftwareApplication must identify the project as free");
+  }
+
+  if (sourceCode) {
+    check(sourceCode.codeRepository === repositoryUrl, "SoftwareSourceCode repository URL is incorrect");
+    check(sourceCode.license === "https://www.apache.org/licenses/LICENSE-2.0", "SoftwareSourceCode license is incorrect");
+    check(Array.isArray(sourceCode.programmingLanguage), "SoftwareSourceCode programmingLanguage must be an array");
+    check(
+      sourceCode.targetProduct?.["@id"] === application?.["@id"],
+      "SoftwareSourceCode must reference its target SoftwareApplication",
+    );
+  }
+}
+
+const html = readSiteFile("index.html");
+const robots = readSiteFile("robots.txt");
+const sitemap = readSiteFile("sitemap.xml");
+
+check(/^<!doctype html>/i.test(html), "index.html must begin with an HTML5 doctype");
+check(/<html\b[^>]*\blang="en"/i.test(html), 'index.html must declare lang="en"');
+check((html.match(/<main\b/gi) ?? []).length === 1, "index.html must contain one main element");
+check((html.match(/<h1\b/gi) ?? []).length === 1, "index.html must contain one h1");
+validateBalancedHtml(html);
+
+const titleMatch = html.match(/<title>([^<]+)<\/title>/i);
+check(titleMatch?.[1] === expectedTitle, "HTML title does not match the expected title");
+const canonical = linkHref(html, "canonical");
+check(canonical === baseUrl, "Canonical URL is incorrect");
+
+const description = metaContent(html, "name", "description");
+const robotsMeta = metaContent(html, "name", "robots");
+const openGraphTitle = metaContent(html, "property", "og:title");
+const openGraphDescription = metaContent(html, "property", "og:description");
+const openGraphUrl = metaContent(html, "property", "og:url");
+const openGraphImage = metaContent(html, "property", "og:image");
+const openGraphImageAlt = metaContent(html, "property", "og:image:alt");
+const twitterTitle = metaContent(html, "name", "twitter:title");
+const twitterDescription = metaContent(html, "name", "twitter:description");
+const twitterImage = metaContent(html, "name", "twitter:image");
+const twitterImageAlt = metaContent(html, "name", "twitter:image:alt");
+
+check(description === expectedDescription, "Meta description is incorrect");
+check(
+  robotsMeta === "index, follow, max-image-preview:large",
+  "Robots meta tag must allow indexing and large image previews",
+);
+check(openGraphTitle === expectedTitle && twitterTitle === expectedTitle, "Social titles must match the HTML title");
+check(
+  openGraphDescription === expectedDescription && twitterDescription === expectedDescription,
+  "Social descriptions must match the meta description",
+);
+check(openGraphUrl === canonical, "og:url must match the canonical URL");
+check(openGraphImage === expectedImage && twitterImage === expectedImage, "Open Graph and Twitter images must match");
+check(
+  Boolean(openGraphImageAlt) && openGraphImageAlt === twitterImageAlt,
+  "Open Graph and Twitter image alt text must be present and match",
+);
+
+const ids = elements(html, "[a-z][\\w-]*")
+  .map(({ attributes }) => attributes.id)
+  .filter(Boolean);
+const duplicateIds = ids.filter((id, index) => ids.indexOf(id) !== index);
+check(duplicateIds.length === 0, `Duplicate HTML ids: ${[...new Set(duplicateIds)].join(", ")}`);
+
+for (const { attributes, source } of elements(html, "a")) {
+  const href = attributes.href;
+  check(Boolean(href), `Anchor is missing href: ${source}`);
+  validateLocalUrl(href, "anchor");
+  if (href) {
+    const target = new URL(href, baseUrl);
+    if (target.origin === new URL(baseUrl).origin && target.pathname === new URL(baseUrl).pathname && target.hash) {
+      check(ids.includes(target.hash.slice(1)), `Fragment link has no matching id: ${href}`);
+    }
+  }
+}
+
+for (const { attributes, source } of elements(html, "img")) {
+  check(Boolean(attributes.alt?.trim()), `Image requires descriptive alt text: ${source}`);
+  validateLocalUrl(attributes.src, "image");
+}
+
+for (const { attributes } of elements(html, "link")) {
+  validateLocalUrl(attributes.href, "link");
+}
+
+validateJsonLd(html);
+
+check(/^User-agent:\s*\*$/m.test(robots), "robots.txt must define the default user agent");
+check(/^Allow:\s*\/meme-search\/$/m.test(robots), "robots.txt must allow the deployed base path");
+check(!/^Disallow:/m.test(robots), "robots.txt must not disallow crawlable content");
+check(
+  new RegExp(`^Sitemap:\\s*${baseUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}sitemap\\.xml$`, "m").test(robots),
+  "robots.txt must advertise the deployed sitemap URL",
+);
+
+check(/^<\?xml version="1\.0" encoding="UTF-8"\?>/.test(sitemap), "sitemap.xml must have an XML declaration");
+check(
+  /<urlset xmlns="http:\/\/www\.sitemaps\.org\/schemas\/sitemap\/0\.9">/.test(sitemap),
+  "sitemap.xml must use the sitemap protocol namespace",
+);
+const sitemapUrls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+check(sitemapUrls.length === 1, `Expected one canonical sitemap URL, found ${sitemapUrls.length}`);
+check(sitemapUrls[0] === canonical, "The sitemap URL must match the canonical URL");
+for (const url of sitemapUrls) validateLocalUrl(url, "sitemap");
+check(
+  (sitemap.match(/<url>/g) ?? []).length === (sitemap.match(/<\/url>/g) ?? []).length,
+  "sitemap.xml has unbalanced url elements",
+);
+check(sitemap.trimEnd().endsWith("</urlset>"), "sitemap.xml must close its urlset");
+
+try {
+  check(statSync(join(siteRoot, ".nojekyll")).isFile(), "site/.nojekyll must be present");
+} catch {
+  errors.push("site/.nojekyll must be present");
+}
+
+if (errors.length > 0) {
+  console.error(`Site validation failed with ${errors.length} error(s):`);
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(
+  `Site validation passed: HTML structure, metadata, JSON-LD, local links, robots.txt, and ${sitemapUrls.length} sitemap URL checked.`,
+);

--- a/site/index.html
+++ b/site/index.html
@@ -3,32 +3,125 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Open source meme search engine. Use AI to index your memes by content and text, then find them instantly with semantic search. Self-host with Docker.">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="description" content="Open source meme search engine that uses local AI to index images by content and text for semantic search. Self-host with Docker.">
   <link rel="canonical" href="https://neonwatty.github.io/meme-search/">
   <meta property="og:title" content="Meme Search - AI-powered meme search engine you can self-host">
-  <meta property="og:description" content="Index your memes by content and text using local AI models. Semantic search, tags, filters, dark mode, and drag-and-drop upload. Free and open source.">
+  <meta property="og:description" content="Open source meme search engine that uses local AI to index images by content and text for semantic search. Self-host with Docker.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://neonwatty.github.io/meme-search/">
+  <meta property="og:site_name" content="Meme Search">
+  <meta property="og:locale" content="en_US">
   <meta property="og:image" content="https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5">
+  <meta property="og:image:width" content="480">
+  <meta property="og:image:height" content="520">
+  <meta property="og:image:type" content="image/webp">
+  <meta property="og:image:alt" content="Meme Search interface showing semantic meme search results">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Meme Search - AI-powered meme search engine you can self-host">
-  <meta name="twitter:description" content="Index your memes by content and text using local AI by default, with optional OpenAI-compatible vision providers.">
+  <meta name="twitter:description" content="Open source meme search engine that uses local AI to index images by content and text for semantic search. Self-host with Docker.">
   <meta name="twitter:image" content="https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5">
+  <meta name="twitter:image:alt" content="Meme Search interface showing semantic meme search results">
   <title>Meme Search - AI-powered meme search engine you can self-host</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="/meme-search/styles.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://neonwatty.github.io/meme-search/#website",
+          "url": "https://neonwatty.github.io/meme-search/",
+          "name": "Meme Search",
+          "description": "Open source meme search engine that uses local AI to index images by content and text for semantic search. Self-host with Docker.",
+          "inLanguage": "en",
+          "publisher": {
+            "@id": "https://neonwatty.github.io/meme-search/#author"
+          },
+          "mainEntity": {
+            "@id": "https://neonwatty.github.io/meme-search/#software"
+          }
+        },
+        {
+          "@type": "SoftwareApplication",
+          "@id": "https://neonwatty.github.io/meme-search/#software",
+          "name": "Meme Search",
+          "url": "https://neonwatty.github.io/meme-search/",
+          "description": "Open source meme search engine that uses local AI to index images by content and text for semantic search. Self-host with Docker.",
+          "applicationCategory": "UtilitiesApplication",
+          "applicationSubCategory": "Media management and semantic search",
+          "operatingSystem": [
+            "Linux",
+            "macOS",
+            "Windows"
+          ],
+          "isAccessibleForFree": true,
+          "license": "https://www.apache.org/licenses/LICENSE-2.0",
+          "image": "https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5",
+          "screenshot": "https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5",
+          "featureList": [
+            "Semantic image search",
+            "Local AI-generated image descriptions",
+            "Keyword search",
+            "Tags and directory filters",
+            "Bulk description generation",
+            "Drag-and-drop uploads"
+          ],
+          "softwareRequirements": "Docker with Docker Compose",
+          "downloadUrl": "https://github.com/neonwatty/meme-search/releases/latest",
+          "sameAs": "https://github.com/neonwatty/meme-search",
+          "author": {
+            "@id": "https://neonwatty.github.io/meme-search/#author"
+          }
+        },
+        {
+          "@type": "SoftwareSourceCode",
+          "@id": "https://neonwatty.github.io/meme-search/#source",
+          "name": "Meme Search source code",
+          "url": "https://github.com/neonwatty/meme-search",
+          "description": "Apache-2.0 licensed source code for the Meme Search self-hosted web application and local AI image-description service.",
+          "codeRepository": "https://github.com/neonwatty/meme-search",
+          "license": "https://www.apache.org/licenses/LICENSE-2.0",
+          "programmingLanguage": [
+            "Ruby",
+            "Python",
+            "JavaScript"
+          ],
+          "runtimePlatform": [
+            "Docker",
+            "Ruby on Rails",
+            "Python",
+            "PostgreSQL"
+          ],
+          "targetProduct": {
+            "@id": "https://neonwatty.github.io/meme-search/#software"
+          },
+          "author": {
+            "@id": "https://neonwatty.github.io/meme-search/#author"
+          }
+        },
+        {
+          "@type": "Person",
+          "@id": "https://neonwatty.github.io/meme-search/#author",
+          "name": "Jeremy Watt",
+          "url": "https://neonwatty.com/"
+        }
+      ]
+    }
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
-    <a class="brand" href="#main" aria-label="Meme Search home">
+    <a class="brand" href="/meme-search/" aria-label="Meme Search home">
       <span class="brand-mark">M</span>
       <span>Meme Search</span>
     </a>
     <nav aria-label="Primary navigation">
-      <a href="#features">Features</a>
-      <a href="#how">How it works</a>
-      <a href="#models">Models</a>
-      <a href="#install">Install</a>
+      <a href="/meme-search/#features">Features</a>
+      <a href="/meme-search/#how">How it works</a>
+      <a href="/meme-search/#models">Models</a>
+      <a href="/meme-search/#install">Install</a>
       <a href="https://discord.gg/7xsxU4ZG6A">Discord</a>
       <a href="https://github.com/neonwatty/meme-search">GitHub</a>
     </nav>
@@ -42,7 +135,7 @@
         <p class="lede">
           Meme Search uses AI to index your memes by their content and text, making them instantly retrievable with semantic search. Processing is local by default, with an optional OpenAI-compatible vision provider.
         </p>
-        <div class="actions" aria-label="Primary actions">
+        <div class="actions" role="group" aria-label="Primary actions">
           <a class="button primary" href="https://github.com/neonwatty/meme-search#installation-instructions">Get started</a>
           <a class="button secondary" href="https://github.com/neonwatty/meme-search">View on GitHub</a>
         </div>
@@ -54,16 +147,16 @@
         </div>
       </div>
 
-      <div class="hero-demo" aria-label="Meme Search demo">
-        <img src="https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5" alt="Meme Search demo showing semantic search in action" loading="eager">
+      <div class="hero-demo">
+        <img src="https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5" alt="Meme Search interface showing semantic meme search results" width="480" height="520" loading="eager" fetchpriority="high">
       </div>
     </section>
 
-    <section class="section intro">
+    <div class="section intro">
       <p>
         Your memes deserve better than scrolling through folders. Index them once with local AI, then search by meaning &mdash; not just filenames.
       </p>
-    </section>
+    </div>
 
     <section id="features" class="section">
       <div class="section-heading">
@@ -120,27 +213,27 @@
 
       <div class="demo-grid">
         <figure class="demo-card">
-          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-pro-search-example.gif?raw=true" alt="Search demo" loading="lazy">
+          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-pro-search-example.gif?raw=true" alt="Meme Search results for a natural-language query" width="1132" height="846" loading="lazy">
           <figcaption>Semantic Search</figcaption>
         </figure>
         <figure class="demo-card">
-          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-pro-edit-example.gif?raw=true" alt="Edit demo" loading="lazy">
+          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-pro-edit-example.gif?raw=true" alt="Editing an indexed meme description in Meme Search" width="1140" height="834" loading="lazy">
           <figcaption>Edit Descriptions</figcaption>
         </figure>
         <figure class="demo-card">
-          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-pro-filters-example.gif?raw=true" alt="Filter demo" loading="lazy">
+          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-pro-filters-example.gif?raw=true" alt="Filtering Meme Search results by tags and directories" width="1140" height="834" loading="lazy">
           <figcaption>Tags and Filters</figcaption>
         </figure>
         <figure class="demo-card">
-          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-generate-example.gif?raw=true" alt="Generate demo" loading="lazy">
+          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-generate-example.gif?raw=true" alt="Generating an AI description for a meme" width="1140" height="834" loading="lazy">
           <figcaption>Auto-Generate</figcaption>
         </figure>
         <figure class="demo-card">
-          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-2.0-bulk.gif?raw=true" alt="Bulk generation demo" loading="lazy">
+          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-2.0-bulk.gif?raw=true" alt="Selecting multiple memes for bulk AI description generation" width="452" height="476" loading="lazy">
           <figcaption>Bulk Generation</figcaption>
         </figure>
         <figure class="demo-card">
-          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-2.0-dark-mode.gif?raw=true" alt="Dark mode demo" loading="lazy">
+          <img src="https://github.com/jermwatt/readme_gifs/blob/main/meme-search-2.0-dark-mode.gif?raw=true" alt="Switching the Meme Search interface to dark mode" width="672" height="720" loading="lazy">
           <figcaption>Dark Mode</figcaption>
         </figure>
       </div>
@@ -179,32 +272,32 @@
       <div class="model-grid">
         <article class="model-card">
           <span class="model-size">250M params</span>
-          <span class="model-name">Florence-2-base <span class="default-badge">Default</span></span>
+          <h3 class="model-name">Florence-2-base <span class="default-badge">Default</span></h3>
           <p>Microsoft's compact vision-language model. Best balance of speed and quality for most setups.</p>
         </article>
         <article class="model-card">
           <span class="model-size">700M params</span>
-          <span class="model-name">Florence-2-large</span>
+          <h3 class="model-name">Florence-2-large</h3>
           <p>Larger Florence variant for richer descriptions when you have the RAM to spare.</p>
         </article>
         <article class="model-card">
           <span class="model-size">256M params</span>
-          <span class="model-name">SmolVLM-256</span>
+          <h3 class="model-name">SmolVLM-256</h3>
           <p>Hugging Face's lightweight model. Fast inference on minimal hardware.</p>
         </article>
         <article class="model-card">
           <span class="model-size">500M params</span>
-          <span class="model-name">SmolVLM-500</span>
+          <h3 class="model-name">SmolVLM-500</h3>
           <p>Mid-range SmolVLM variant. Better descriptions than 256M with moderate resource use.</p>
         </article>
         <article class="model-card">
           <span class="model-size">2B params</span>
-          <span class="model-name">Moondream2</span>
+          <h3 class="model-name">Moondream2</h3>
           <p>Full-size vision-language model. Best description quality, needs ~5GB memory.</p>
         </article>
         <article class="model-card">
           <span class="model-size">2B INT8</span>
-          <span class="model-name">Moondream2-INT8</span>
+          <h3 class="model-name">Moondream2-INT8</h3>
           <p>Quantized Moondream2. Cuts memory to ~1.5-2GB with minimal quality loss. Ideal for CPU-only machines.</p>
         </article>
       </div>

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /meme-search/
+
+Sitemap: https://neonwatty.github.io/meme-search/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://neonwatty.github.io/meme-search/</loc>
+  </url>
+</urlset>

--- a/site/styles.css
+++ b/site/styles.css
@@ -328,6 +328,7 @@ h3 {
 }
 
 .model-name {
+  margin: 0;
   font-weight: 700;
   color: var(--text);
 }


### PR DESCRIPTION
## Summary

- add GitHub Pages-aware `robots.txt` and `sitemap.xml` using the deployed `/meme-search/` base path
- add consistent canonical, robots, Open Graph, Twitter, `WebSite`, `SoftwareApplication`, and `SoftwareSourceCode` metadata
- improve crawl-safe navigation, heading/ARIA semantics, descriptive image alternatives, and explicit image dimensions
- add a dependency-free site validator and make Pages deployment depend on it
- add a README backlink and a prioritized supporting-content plan that leaves NAS and Chinese documentation to their separate initiatives

## Why

The landing page already had strong positioning and social metadata, but its project-path robots and sitemap endpoints returned 404. Structured data, base-path link safety, and automated regression coverage were also missing.

This establishes the technical SEO foundation without adding thin crawlable pages, analytics, DNS changes, or a visual redesign.

## User-visible behavior

After merge and Pages deployment, `/meme-search/robots.txt` and `/meme-search/sitemap.xml` will resolve, page metadata will be consistent across search and social consumers, and navigation remains safe under the GitHub Pages project base path. Visual presentation is unchanged apart from more stable image layout and corrected semantic markup.

## Verification

- `npm run test:site`
- W3C Nu HTML checker: 0 errors, 0 warnings
- Schema.org Markup Validator: 0 errors, 0 warnings
- `xmllint --noout site/sitemap.xml`
- local project-base smoke test: page, CSS, robots, and sitemap returned 200 with expected content types
- all 18 visible external links and image targets returned 200
- `git diff --check`

The Rails, Python, and Docker suites were not run because application code and runtime behavior are untouched.

## Post-deployment check

Verify all four project URLs return 200 and submit the sitemap through search-console tooling. GitHub Project Pages can publish `/meme-search/robots.txt`, but the Robots Exclusion Protocol discovers rules at origin-level `/robots.txt`; that separate URL is controlled by the `neonwatty.github.io` user-site repository.

- [x] Focused automated tests pass
- [x] Documentation and configuration examples were updated where needed
- [x] Docker E2E is not applicable
- [x] No secrets, private image data, or personal filesystem paths are included