### PR TITLE
Add experimental local Chromium search extension

### DIFF
--- a/.github/workflows/pro-app-test.yml
+++ b/.github/workflows/pro-app-test.yml
@@ -11,6 +11,7 @@ on:
       - "playwright.config.ts"
       - "playwright/**"
       - "playwright-docker/**"
+      - "integrations/browser-extension/**"
       - "meme_search/meme_search_app/**"
       - ".github/workflows/pro-app-test.yml"
       - "README.md"
@@ -26,6 +27,7 @@ on:
       - "playwright.config.ts"
       - "playwright/**"
       - "playwright-docker/**"
+      - "integrations/browser-extension/**"
       - "meme_search/meme_search_app/**"
       - ".github/workflows/pro-app-test.yml"
       - "README.md"
@@ -90,6 +92,29 @@ jobs:
       - name: Scan for security vulnerabilities in JavaScript dependencies
         working-directory: ./meme_search/meme_search_app
         run: bin/importmap audit
+
+  browser_extension:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+
+      - name: Test browser extension
+        working-directory: ./integrations/browser-extension
+        run: |
+          npm ci
+          npm test
+          npm run check
+          npm audit --audit-level=high
+          node -e 'JSON.parse(require("fs").readFileSync("manifest.json", "utf8")); console.log("manifest ok")'
+          ! rg 'innerHTML|outerHTML|insertAdjacentHTML' . --glob '*.js'
+          ! rg --pcre2 'https?://(?!127\.0\.0\.1|localhost)' . --glob '*.js' --glob '!test/**'
 
   pro_app_lint:
     runs-on: ubuntu-latest

--- a/integrations/browser-extension/README.md
+++ b/integrations/browser-extension/README.md
@@ -1,0 +1,118 @@
+# Meme Search Local browser extension
+
+This is a small, unpacked Chromium extension for searching a Meme Search
+collection without opening the web app. Result cards show metadata and can copy
+or download the selected meme.
+
+Search and scrolling fetch no media. API v1 has no bounded thumbnail
+representation, so the popup intentionally avoids automatic previews instead
+of downloading full originals in the background. **Copy image** fetches only
+the selected original and converts it to PNG for broad clipboard
+compatibility. For an animated GIF, copy is a still frame; use **Download** to
+fetch and preserve the original animation.
+
+## Prerequisites
+
+- Meme Search running locally at `http://127.0.0.1:3000` (the default) or an `http://localhost` URL.
+- A read-only API token with the `search:read` and `media:read` scopes.
+
+Create a token from **Settings → API tokens**. Select both read scopes and copy
+the one-time value immediately.
+
+For Docker, the equivalent task is:
+
+```sh
+docker compose exec meme_search bin/rails api_tokens:create \
+  NAME="Browser extension" SCOPES="search:read,media:read"
+```
+
+For a native checkout, run from `meme_search/meme_search_app`:
+
+```sh
+bin/rails api_tokens:create NAME="Browser extension" SCOPES="search:read,media:read"
+```
+
+The raw token is shown once. Do not commit or paste it into logs.
+
+## Load the unpacked extension
+
+1. Open `chrome://extensions` in Chrome, Chromium, Brave, or Edge.
+2. Enable **Developer mode**.
+3. Choose **Load unpacked** and select this `integrations/browser-extension` directory.
+4. Open the extension's settings, enter the local server URL and token, and choose **Save connection**.
+5. Pin the extension, open its popup, and search.
+
+The extension is an MVP for local installation. It is not packaged or
+published to an extension store. Official support is Chromium-only and
+loopback-only.
+
+## Security boundary
+
+- Host access is optional and limited to `http://127.0.0.1/*` and `http://localhost/*`. The extension cannot be configured for LAN or internet hosts.
+- The host prompt is required because Chromium extensions need explicit permission to call the selected local origin. No blanket web access is requested.
+- The bearer token is stored unencrypted in `chrome.storage.local` in the current browser profile. Other people or software with access to that profile may be able to recover it. It is never placed in a query string or an image URL.
+- Search results expose relative API URLs. The extension accepts only the configured origin's `/api/v1/memes/:id/content` route. It makes no media request while rendering or scrolling results; copy and download authenticate and fetch only after the explicit button action.
+- Authenticated fetches reject redirects, cross-origin URLs, query-bearing content URLs, malformed result shapes, and non-image responses.
+- Keep the token read-only and revoke it if the browser profile or computer is compromised.
+- The token secures API routes only. It does not make the unauthenticated Meme Search web interface safe to expose on a network; continue using the project's loopback-only deployment defaults.
+- The extension includes no telemetry, analytics, remote service, or update server.
+
+## Revoke, rotate, or repair settings
+
+Revoke a lost token from **Settings → API tokens**. You can also use:
+
+```sh
+# Docker
+docker compose exec meme_search bin/rails api_tokens:list
+docker compose exec meme_search bin/rails api_tokens:revoke PREFIX="ms_abcd1234"
+
+# Native, from meme_search/meme_search_app
+bin/rails api_tokens:list
+bin/rails api_tokens:revoke PREFIX="ms_abcd1234"
+```
+
+Create a replacement before revoking an active token, save it on the extension
+settings page, then reload the extension from `chrome://extensions`. If an
+invalid legacy URL was saved, the settings page still opens and lets you
+replace it.
+
+## Limitations
+
+- Unpacked Chromium browsers only; no Chrome Web Store, Firefox, Safari, mobile,
+  or managed-enterprise distribution support.
+- Loopback HTTP only; LAN hosts, public hosts, HTTPS origins, and remote proxies
+  are rejected.
+- Search supports keyword and semantic modes plus result limits. Tag selection
+  remains available in the web UI and CLI.
+- Result cards are metadata-only. **Copy image** converts to PNG, so an
+  animated GIF copies as a still frame; **Download** preserves the original
+  bytes and animation.
+- Clipboard and optional-host permission behavior depends on the browser and
+  must be confirmed in an interactively loaded extension.
+
+## Manual smoke checklist
+
+After loading or changing the extension:
+
+1. Open settings, save `http://127.0.0.1:3000` and a token with both scopes,
+   and accept only the loopback host prompt.
+2. Search once in Keyword mode and once in Semantic mode without opening the
+   web app; confirm metadata cards appear and no media requests occur.
+3. Copy a PNG/JPEG and paste it into a local editor. For a GIF, confirm copy is
+   a still PNG and Download preserves the animated `.gif`.
+4. Download a result and confirm its safe filename and original bytes.
+5. Replace the token with an invalid value and confirm the popup gives a
+   concise 401 error without displaying the token.
+6. Revoke the valid token in Meme Search and confirm subsequent searches fail.
+7. Correct the saved token, reload the extension, and confirm search recovers.
+
+## Development
+
+No install step or third-party dependency is required. Node.js 20 can run the contract tests and syntax checks:
+
+```sh
+npm test
+npm run check
+```
+
+After editing extension files, use the reload button for this extension on `chrome://extensions`.

--- a/integrations/browser-extension/lib/api-client.js
+++ b/integrations/browser-extension/lib/api-client.js
@@ -1,0 +1,164 @@
+import { normalizeBaseUrl, resolveApiUrl } from "./url.js";
+
+const SEARCH_MODES = new Set(["keyword", "vector"]);
+
+function authorizationHeader(token) {
+  const value = String(token || "").trim();
+  if (!value) throw new Error("Add an API token in extension settings.");
+  return `Bearer ${value}`;
+}
+
+function redactSecret(message, token) {
+  const secret = String(token || "").trim();
+  return secret ? message.replaceAll(secret, "[REDACTED]") : message;
+}
+
+async function responseError(response, token) {
+  let serverMessage;
+
+  try {
+    const body = await response.json();
+    serverMessage = body?.error?.message || body?.error;
+  } catch {
+    // An HTML proxy error or empty response should not leak into the popup.
+  }
+
+  if (typeof serverMessage === "string" && serverMessage.trim()) {
+    return redactSecret(serverMessage.trim(), token);
+  }
+
+  switch (response.status) {
+    case 401:
+      return "The API token is missing or invalid.";
+    case 403:
+      return "This token does not have the required permission.";
+    case 429:
+      return "Too many searches. Wait a moment and try again.";
+    default:
+      return `Meme Search returned HTTP ${response.status}.`;
+  }
+}
+
+async function fetchAuthorized(url, token, fetchImpl, accept, signal) {
+  let response;
+
+  try {
+    response = await fetchImpl(url, {
+      headers: {
+        Accept: accept,
+        Authorization: authorizationHeader(token)
+      },
+      redirect: "error",
+      signal
+    });
+  } catch (error) {
+    if (error?.name === "AbortError") throw error;
+    throw new Error("Could not reach Meme Search. Check that it is running and the URL is correct.");
+  }
+
+  if (response.redirected) {
+    throw new Error("Meme Search returned an unexpected redirect.");
+  }
+  if (!response.ok) throw new Error(await responseError(response, token));
+  return response;
+}
+
+export function validateSearchResponse(body, baseUrl) {
+  if (!body || !Array.isArray(body.data) || !body.meta || typeof body.meta !== "object") {
+    throw new Error("Meme Search returned an unexpected response.");
+  }
+
+  const { meta } = body;
+  if (
+    typeof meta.query !== "string"
+    || !SEARCH_MODES.has(meta.mode)
+    || !Array.isArray(meta.tags)
+    || !meta.tags.every((tag) => typeof tag === "string")
+    || !Number.isInteger(meta.limit)
+    || meta.limit < 1
+    || meta.limit > 20
+    || !Number.isInteger(meta.count)
+    || meta.count < 0
+    || meta.count > 20
+  ) {
+    throw new Error("Meme Search returned an unexpected response.");
+  }
+
+  for (const meme of body.data) {
+    if (
+      !meme
+      || !Number.isInteger(meme.id)
+      || meme.id < 1
+      || typeof meme.filename !== "string"
+      || (meme.description !== null && typeof meme.description !== "string")
+      || !Array.isArray(meme.tags)
+      || !meme.tags.every((tag) => typeof tag === "string")
+      || typeof meme.media_type !== "string"
+      || typeof meme.content_url !== "string"
+    ) {
+      throw new Error("Meme Search returned an unexpected response.");
+    }
+    resolveApiUrl(baseUrl, meme.content_url);
+  }
+}
+
+export async function searchMemes(
+  { baseUrl, token, query, mode = "keyword", limit = 8, signal },
+  fetchImpl = fetch
+) {
+  const trimmedQuery = String(query || "").trim();
+  const parsedLimit = Number(limit);
+
+  if (!trimmedQuery) throw new Error("Enter a search query.");
+  if (trimmedQuery.length > 200) throw new Error("Search queries must be 200 characters or fewer.");
+  if (!SEARCH_MODES.has(mode)) throw new Error("Choose a supported search mode.");
+  if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > 20) {
+    throw new Error("Result limit must be between 1 and 20.");
+  }
+
+  const url = new URL("/api/v1/search", `${normalizeBaseUrl(baseUrl)}/`);
+  url.searchParams.set("q", trimmedQuery);
+  url.searchParams.set("mode", mode);
+  url.searchParams.set("limit", String(parsedLimit));
+
+  const response = await fetchAuthorized(
+    url,
+    token,
+    fetchImpl,
+    "application/json",
+    signal
+  );
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error("Meme Search returned invalid JSON.");
+  }
+  validateSearchResponse(body, baseUrl);
+
+  return {
+    data: body.data,
+    meta: body.meta
+  };
+}
+
+export async function fetchMemeContent(
+  { baseUrl, token, contentUrl, signal },
+  fetchImpl = fetch
+) {
+  const url = resolveApiUrl(baseUrl, contentUrl);
+  const response = await fetchAuthorized(
+    url,
+    token,
+    fetchImpl,
+    "image/*,application/octet-stream",
+    signal
+  );
+  const blob = await response.blob();
+
+  if (!blob.type.startsWith("image/")) {
+    throw new Error("Meme Search returned a non-image file.");
+  }
+
+  return blob;
+}

--- a/integrations/browser-extension/lib/clipboard.js
+++ b/integrations/browser-extension/lib/clipboard.js
@@ -1,0 +1,27 @@
+import { convertToPng } from "./image-conversion.js";
+
+export function writePngToClipboard(pngPromise, dependencies = {}) {
+  const clipboard = dependencies.clipboard ?? globalThis.navigator?.clipboard;
+  const ClipboardItemConstructor =
+    dependencies.ClipboardItemConstructor ?? globalThis.ClipboardItem;
+
+  if (!clipboard?.write || typeof ClipboardItemConstructor !== "function") {
+    throw new Error("Image copying is not available in this browser.");
+  }
+
+  const item = new ClipboardItemConstructor({ "image/png": pngPromise });
+  return clipboard.write([item]);
+}
+
+export function copyOriginalToClipboard(
+  session,
+  loadBlob,
+  dependencies = {}
+) {
+  const convert = dependencies.convertToPng ?? convertToPng;
+  const pngPromise = session.runOriginal(
+    loadBlob,
+    (blob, signal) => convert(blob, signal)
+  );
+  return writePngToClipboard(pngPromise, dependencies);
+}

--- a/integrations/browser-extension/lib/filename.js
+++ b/integrations/browser-extension/lib/filename.js
@@ -1,0 +1,10 @@
+export function safeFilename(value) {
+  const basename = String(value || "meme")
+    .split(/[\\/]/)
+    .pop()
+    .replace(/[^\w.\- ()]+/g, "_")
+    .replace(/^\.+/, "")
+    .trim();
+
+  return basename || "meme";
+}

--- a/integrations/browser-extension/lib/image-conversion.js
+++ b/integrations/browser-extension/lib/image-conversion.js
@@ -1,0 +1,41 @@
+function throwIfAborted(signal) {
+  if (signal.aborted) throw new DOMException("Media work was cancelled.", "AbortError");
+}
+
+export async function convertToPng(blob, signal, dependencies = {}) {
+  throwIfAborted(signal);
+  if (blob.type === "image/png") return blob;
+
+  const createBitmap = dependencies.createImageBitmap ?? globalThis.createImageBitmap;
+  const createCanvas = dependencies.createCanvas ??
+    (() => globalThis.document.createElement("canvas"));
+  const bitmap = await createBitmap(blob);
+  let canvas;
+  try {
+    throwIfAborted(signal);
+    canvas = createCanvas();
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    canvas.getContext("2d").drawImage(bitmap, 0, 0);
+  } finally {
+    bitmap.close();
+  }
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (pngBlob) => {
+        try {
+          throwIfAborted(signal);
+          if (pngBlob) {
+            resolve(pngBlob);
+          } else {
+            reject(new Error("Could not prepare this image for copying."));
+          }
+        } catch (error) {
+          reject(error);
+        }
+      },
+      "image/png"
+    );
+  });
+}

--- a/integrations/browser-extension/lib/media-work-session.js
+++ b/integrations/browser-extension/lib/media-work-session.js
@@ -1,0 +1,51 @@
+function abortError() {
+  return new DOMException("Media work was cancelled.", "AbortError");
+}
+
+export class MediaWorkSession {
+  constructor({
+    createObjectURL = (blob) => URL.createObjectURL(blob),
+    revokeObjectURL = (url) => URL.revokeObjectURL(url)
+  } = {}) {
+    this.createObjectURL = createObjectURL;
+    this.revokeObjectURL = revokeObjectURL;
+    this.controller = new AbortController();
+    this.objectUrls = new Set();
+    this.closed = false;
+  }
+
+  get signal() {
+    return this.controller.signal;
+  }
+
+  async runOriginal(loadBlob, useBlob) {
+    if (this.closed) throw abortError();
+
+    const blob = await loadBlob(this.signal);
+    if (this.closed || this.signal.aborted) throw abortError();
+    const result = await useBlob(blob, this.signal);
+    if (this.closed || this.signal.aborted) throw abortError();
+    return result;
+  }
+
+  retainObjectUrl(blob) {
+    if (this.closed) throw abortError();
+    const objectUrl = this.createObjectURL(blob);
+    this.objectUrls.add(objectUrl);
+    return objectUrl;
+  }
+
+  releaseObjectUrl(objectUrl) {
+    if (!this.objectUrls.delete(objectUrl)) return;
+    this.revokeObjectURL(objectUrl);
+  }
+
+  cancel() {
+    if (this.closed) return;
+
+    this.closed = true;
+    this.controller.abort();
+    for (const objectUrl of this.objectUrls) this.revokeObjectURL(objectUrl);
+    this.objectUrls.clear();
+  }
+}

--- a/integrations/browser-extension/lib/settings.js
+++ b/integrations/browser-extension/lib/settings.js
@@ -1,0 +1,32 @@
+import { DEFAULT_BASE_URL, normalizeBaseUrl } from "./url.js";
+
+const STORAGE_KEYS = ["baseUrl", "token"];
+
+export function normalizeSettings(settings) {
+  const normalized = {
+    baseUrl: normalizeBaseUrl(settings.baseUrl),
+    token: String(settings.token || "").trim()
+  };
+
+  if (!normalized.token) {
+    throw new Error("Enter an API token.");
+  }
+
+  return normalized;
+}
+
+export async function loadSettings(storage = chrome.storage.local) {
+  const stored = await storage.get(STORAGE_KEYS);
+
+  return {
+    baseUrl: normalizeBaseUrl(stored.baseUrl || DEFAULT_BASE_URL),
+    token: typeof stored.token === "string" ? stored.token.trim() : ""
+  };
+}
+
+export async function saveSettings(settings, storage = chrome.storage.local) {
+  const normalized = normalizeSettings(settings);
+
+  await storage.set(normalized);
+  return normalized;
+}

--- a/integrations/browser-extension/lib/url.js
+++ b/integrations/browser-extension/lib/url.js
@@ -1,0 +1,51 @@
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost"]);
+
+export const DEFAULT_BASE_URL = "http://127.0.0.1:3000";
+
+export function normalizeBaseUrl(value) {
+  let url;
+
+  try {
+    url = new URL(String(value).trim());
+  } catch {
+    throw new Error("Enter a valid Meme Search URL.");
+  }
+
+  if (url.protocol !== "http:" || !LOOPBACK_HOSTS.has(url.hostname)) {
+    throw new Error("The extension only connects to http://localhost or http://127.0.0.1.");
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("The Meme Search URL cannot include credentials, a query, or a fragment.");
+  }
+
+  if (url.pathname !== "/" && url.pathname !== "") {
+    throw new Error("Use the server origin only, without a path.");
+  }
+
+  return url.origin;
+}
+
+export function hostPermissionPattern(baseUrl) {
+  const url = new URL(normalizeBaseUrl(baseUrl));
+  return `${url.protocol}//${url.hostname}/*`;
+}
+
+export function resolveApiUrl(baseUrl, path) {
+  const base = new URL(`${normalizeBaseUrl(baseUrl)}/`);
+  const resolved = new URL(path, base);
+
+  if (resolved.origin !== base.origin) {
+    throw new Error("The server returned an unsafe media URL.");
+  }
+
+  if (
+    resolved.search
+    || resolved.hash
+    || !/^\/api\/v1\/memes\/[1-9][0-9]*\/content$/.test(resolved.pathname)
+  ) {
+    throw new Error("The server returned an unexpected media URL.");
+  }
+
+  return resolved;
+}

--- a/integrations/browser-extension/manifest.json
+++ b/integrations/browser-extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Meme Search Local",
+  "description": "Search your local Meme Search collection from the browser toolbar.",
+  "version": "0.1.0",
+  "action": {
+    "default_title": "Search memes",
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html",
+  "permissions": [
+    "clipboardWrite",
+    "storage"
+  ],
+  "optional_host_permissions": [
+    "http://127.0.0.1/*",
+    "http://localhost/*"
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  }
+}

--- a/integrations/browser-extension/options.html
+++ b/integrations/browser-extension/options.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Meme Search settings</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body class="options">
+    <main class="settings-panel">
+      <p class="eyebrow">Meme Search Local</p>
+      <h1>Extension settings</h1>
+      <p class="settings-intro">Connect to the Meme Search instance running on this computer. The extension does not support remote hosts.</p>
+
+      <form id="settings-form">
+        <label for="base-url">Server URL</label>
+        <input id="base-url" name="baseUrl" type="url" inputmode="url" placeholder="http://127.0.0.1:3000" required>
+        <p class="field-help">Allowed: <code>http://127.0.0.1</code> or <code>http://localhost</code>, with an optional port.</p>
+
+        <label for="token">Read-only API token</label>
+        <input id="token" name="token" type="password" autocomplete="off" spellcheck="false" required>
+        <p class="field-help">Use a token scoped only to <code>search:read</code> and <code>media:read</code>. It is stored in this browser profile.</p>
+
+        <button class="primary-button" type="submit">Save connection</button>
+      </form>
+      <p id="settings-status" class="status" role="status" aria-live="polite"></p>
+    </main>
+
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/integrations/browser-extension/options.js
+++ b/integrations/browser-extension/options.js
@@ -1,0 +1,74 @@
+import { loadSettings, normalizeSettings, saveSettings } from "./lib/settings.js";
+import { hostPermissionPattern } from "./lib/url.js";
+
+const form = document.querySelector("#settings-form");
+const baseUrlInput = document.querySelector("#base-url");
+const tokenInput = document.querySelector("#token");
+const status = document.querySelector("#settings-status");
+
+function setStatus(message, kind = "") {
+  status.textContent = message;
+  status.dataset.kind = kind;
+}
+
+async function initialize() {
+  try {
+    const settings = await loadSettings();
+    baseUrlInput.value = settings.baseUrl;
+    tokenInput.value = settings.token;
+  } catch (error) {
+    setStatus(error.message, "error");
+  }
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  setStatus("Requesting local server access…");
+  form.querySelector("button[type=submit]").disabled = true;
+
+  try {
+    const normalized = normalizeSettings({
+      baseUrl: baseUrlInput.value,
+      token: tokenInput.value
+    });
+    const requestedPattern = hostPermissionPattern(normalized.baseUrl);
+    const alreadyGranted = await chrome.permissions.contains({
+      origins: [requestedPattern]
+    });
+    if (!alreadyGranted) {
+      const granted = await chrome.permissions.request({ origins: [requestedPattern] });
+      if (!granted) throw new Error("Local server access was not granted.");
+    }
+
+    let previousPattern;
+    try {
+      const previous = await loadSettings();
+      previousPattern = hostPermissionPattern(previous.baseUrl);
+    } catch {
+      // A valid save must be able to repair malformed legacy storage.
+    }
+
+    let settings;
+    try {
+      settings = await saveSettings(normalized);
+    } catch (error) {
+      if (!alreadyGranted) {
+        await chrome.permissions.remove({ origins: [requestedPattern] });
+      }
+      throw error;
+    }
+
+    if (previousPattern && previousPattern !== requestedPattern) {
+      await chrome.permissions.remove({ origins: [previousPattern] });
+    }
+
+    baseUrlInput.value = settings.baseUrl;
+    setStatus("Connection saved.", "success");
+  } catch (error) {
+    setStatus(error.message, "error");
+  } finally {
+    form.querySelector("button[type=submit]").disabled = false;
+  }
+});
+
+initialize();

--- a/integrations/browser-extension/package-lock.json
+++ b/integrations/browser-extension/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "meme-search-browser-extension",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "meme-search-browser-extension"
+    }
+  }
+}

--- a/integrations/browser-extension/package.json
+++ b/integrations/browser-extension/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "meme-search-browser-extension",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test",
+    "check": "node --check popup.js && node --check options.js && node --check lib/api-client.js && node --check lib/clipboard.js && node --check lib/filename.js && node --check lib/image-conversion.js && node --check lib/media-work-session.js && node --check lib/settings.js && node --check lib/url.js"
+  }
+}

--- a/integrations/browser-extension/popup.html
+++ b/integrations/browser-extension/popup.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Meme Search</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body class="popup">
+    <header class="app-header">
+      <div>
+        <p class="eyebrow">Local collection</p>
+        <h1>Meme Search</h1>
+      </div>
+      <button id="open-settings" class="icon-button" type="button" aria-label="Open settings" title="Settings">⚙</button>
+    </header>
+
+    <main>
+      <form id="search-form" class="search-form">
+        <label class="sr-only" for="query">Search your memes</label>
+        <div class="search-row">
+          <input id="query" name="query" type="search" maxlength="200" placeholder="production incident…" autocomplete="off" autofocus required>
+          <button class="primary-button" type="submit">Search</button>
+        </div>
+        <div class="search-options">
+          <label for="mode">Mode</label>
+          <select id="mode" name="mode">
+            <option value="keyword">Keyword</option>
+            <option value="vector">Semantic</option>
+          </select>
+          <label for="limit">Results</label>
+          <select id="limit" name="limit">
+            <option value="4">4</option>
+            <option value="8" selected>8</option>
+            <option value="12">12</option>
+            <option value="20">20</option>
+          </select>
+        </div>
+      </form>
+
+      <p id="status" class="status" role="status" aria-live="polite">Search without opening the web app.</p>
+      <section id="results" class="results" aria-label="Search results"></section>
+    </main>
+
+    <template id="result-template">
+      <article class="result-card">
+        <div class="result-details">
+          <h2 class="result-title"></h2>
+          <p class="result-description"></p>
+          <p class="result-tags"></p>
+          <p class="media-note">Media loads only after Copy or Download.</p>
+          <div class="result-actions">
+            <button class="copy-button secondary-button" type="button">Copy image</button>
+            <button class="download-button ghost-button" type="button">Download</button>
+          </div>
+        </div>
+      </article>
+    </template>
+
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/integrations/browser-extension/popup.js
+++ b/integrations/browser-extension/popup.js
@@ -1,0 +1,150 @@
+import { fetchMemeContent, searchMemes } from "./lib/api-client.js";
+import { copyOriginalToClipboard } from "./lib/clipboard.js";
+import { safeFilename } from "./lib/filename.js";
+import { convertToPng } from "./lib/image-conversion.js";
+import { MediaWorkSession } from "./lib/media-work-session.js";
+import { loadSettings } from "./lib/settings.js";
+import { hostPermissionPattern } from "./lib/url.js";
+
+const form = document.querySelector("#search-form");
+const queryInput = document.querySelector("#query");
+const modeInput = document.querySelector("#mode");
+const limitInput = document.querySelector("#limit");
+const status = document.querySelector("#status");
+const results = document.querySelector("#results");
+const template = document.querySelector("#result-template");
+const settingsButton = document.querySelector("#open-settings");
+let activeSession;
+
+function setStatus(message, kind = "") {
+  status.textContent = message;
+  status.dataset.kind = kind;
+}
+
+function clearResults() {
+  activeSession?.cancel();
+  activeSession = undefined;
+  results.replaceChildren();
+}
+
+async function ensureHostPermission(baseUrl) {
+  const origins = [hostPermissionPattern(baseUrl)];
+  if (await chrome.permissions.contains({ origins })) return true;
+  return chrome.permissions.request({ origins });
+}
+
+function downloadBlob(blob, filename, session) {
+  const url = session.retainObjectUrl(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = safeFilename(filename);
+  anchor.click();
+  setTimeout(() => session.releaseObjectUrl(url), 1_000);
+}
+
+function mediaLoader(meme, settings) {
+  return (signal) => fetchMemeContent({
+    baseUrl: settings.baseUrl,
+    token: settings.token,
+    contentUrl: meme.content_url,
+    signal
+  });
+}
+
+function renderMeme(meme, settings, session) {
+  const fragment = template.content.cloneNode(true);
+  const card = fragment.querySelector(".result-card");
+  const title = fragment.querySelector(".result-title");
+  const description = fragment.querySelector(".result-description");
+  const tags = fragment.querySelector(".result-tags");
+  const copyButton = fragment.querySelector(".copy-button");
+  const downloadButton = fragment.querySelector(".download-button");
+
+  title.textContent = meme.filename || `Meme ${meme.id}`;
+  description.textContent = meme.description || "No description";
+  const tagNames = Array.isArray(meme.tags) ? meme.tags.map(String) : [];
+  tags.textContent = tagNames.length ? tagNames.map((tag) => `#${tag}`).join(" ") : "No tags";
+
+  copyButton.addEventListener("click", async () => {
+    copyButton.disabled = true;
+    try {
+      await copyOriginalToClipboard(session, mediaLoader(meme, settings));
+      setStatus(`Copied ${safeFilename(meme.filename)}.`, "success");
+    } catch (error) {
+      if (error.name !== "AbortError" && activeSession === session) {
+        setStatus(error.message, "error");
+      }
+    } finally {
+      if (activeSession === session) copyButton.disabled = false;
+    }
+  });
+
+  downloadButton.addEventListener("click", async () => {
+    downloadButton.disabled = true;
+    try {
+      await session.runOriginal(
+        mediaLoader(meme, settings),
+        (blob) => downloadBlob(blob, meme.filename, session)
+      );
+      setStatus(`Downloaded ${safeFilename(meme.filename)}.`, "success");
+    } catch (error) {
+      if (error.name !== "AbortError" && activeSession === session) {
+        setStatus(error.message, "error");
+      }
+    } finally {
+      if (activeSession === session) downloadButton.disabled = false;
+    }
+  });
+
+  results.append(card);
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  clearResults();
+  const session = new MediaWorkSession();
+  activeSession = session;
+  setStatus("Searching…");
+  form.querySelector("button[type=submit]").disabled = true;
+
+  try {
+    const settings = await loadSettings();
+    if (!settings.token) {
+      chrome.runtime.openOptionsPage();
+      throw new Error("Add an API token in extension settings.");
+    }
+
+    if (!(await ensureHostPermission(settings.baseUrl))) {
+      throw new Error("Local server access was not granted.");
+    }
+
+    const response = await searchMemes({
+      baseUrl: settings.baseUrl,
+      token: settings.token,
+      query: queryInput.value,
+      mode: modeInput.value,
+      limit: Number(limitInput.value),
+      signal: session.signal
+    });
+
+    if (activeSession !== session) return;
+    if (response.data.length === 0) {
+      setStatus("No matching memes found.");
+      return;
+    }
+
+    for (const meme of response.data) renderMeme(meme, settings, session);
+    setStatus(`${response.data.length} result${response.data.length === 1 ? "" : "s"}.`, "success");
+  } catch (error) {
+    if (error.name !== "AbortError" && activeSession === session) {
+      setStatus(error.message, "error");
+    }
+  } finally {
+    if (activeSession === session) {
+      form.querySelector("button[type=submit]").disabled = false;
+    }
+  }
+});
+
+settingsButton.addEventListener("click", () => chrome.runtime.openOptionsPage());
+window.addEventListener("unload", clearResults);

--- a/integrations/browser-extension/styles.css
+++ b/integrations/browser-extension/styles.css
@@ -1,0 +1,309 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182019;
+  background: #f7f8f3;
+  --ink: #182019;
+  --muted: #677068;
+  --line: #d9ded5;
+  --panel: #ffffff;
+  --accent: #c8ff55;
+  --accent-strong: #9ce61b;
+  --error: #a92e24;
+  --success: #327b32;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+body.popup {
+  width: 420px;
+  min-height: 260px;
+  max-height: 600px;
+  overflow-y: auto;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.app-header,
+.settings-panel,
+.search-form,
+.status,
+.results {
+  margin-inline: 16px;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block: 16px 8px;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 20px;
+  letter-spacing: -0.02em;
+}
+
+.eyebrow {
+  margin-bottom: 2px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.icon-button,
+.ghost-button {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--ink);
+}
+
+.icon-button {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+}
+
+.search-form {
+  padding-block: 8px;
+}
+
+.search-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+}
+
+input,
+select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--ink);
+}
+
+input {
+  width: 100%;
+  padding: 8px 10px;
+}
+
+select {
+  padding-inline: 8px 24px;
+}
+
+input:focus-visible,
+select:focus-visible,
+button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent-strong) 50%, transparent);
+  outline-offset: 1px;
+}
+
+.primary-button,
+.secondary-button,
+.ghost-button {
+  min-height: 36px;
+  border-radius: 8px;
+  padding: 7px 12px;
+  font-weight: 700;
+}
+
+.primary-button {
+  border: 1px solid #8ccd1b;
+  background: var(--accent);
+  color: #152006;
+}
+
+.secondary-button {
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: #fff;
+}
+
+.search-options {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.search-options label:not(:first-child) {
+  margin-left: auto;
+}
+
+.search-options select {
+  min-height: 30px;
+  font-size: 12px;
+}
+
+.status {
+  min-height: 20px;
+  margin-block: 8px 12px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.status[data-kind="error"] {
+  color: var(--error);
+}
+
+.status[data-kind="success"] {
+  color: var(--success);
+}
+
+.results {
+  display: grid;
+  gap: 12px;
+  padding-bottom: 16px;
+}
+
+.result-card {
+  min-height: 116px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel);
+}
+
+.result-details {
+  min-width: 0;
+  padding: 10px 10px 10px 0;
+}
+
+.media-note {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.result-title {
+  margin-bottom: 4px;
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.result-description,
+.result-tags {
+  display: -webkit-box;
+  margin-bottom: 6px;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  -webkit-box-orient: vertical;
+}
+
+.result-description {
+  -webkit-line-clamp: 3;
+}
+
+.result-tags {
+  -webkit-line-clamp: 1;
+}
+
+.result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.result-actions button {
+  min-height: 30px;
+  padding: 5px 8px;
+  font-size: 11px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+body.options {
+  min-height: 100vh;
+  padding: 48px 20px;
+}
+
+.settings-panel {
+  max-width: 560px;
+  margin-inline: auto;
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--panel);
+  box-shadow: 0 12px 40px rgb(20 32 10 / 8%);
+}
+
+.settings-panel h1 {
+  margin-bottom: 8px;
+  font-size: 26px;
+}
+
+.settings-intro {
+  margin-bottom: 24px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.settings-panel form {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-panel label {
+  margin-top: 10px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.field-help {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.settings-panel .primary-button {
+  justify-self: start;
+  margin-top: 10px;
+}
+
+.settings-panel .status {
+  margin-inline: 0;
+  margin-bottom: 0;
+}

--- a/integrations/browser-extension/test/api-client.test.js
+++ b/integrations/browser-extension/test/api-client.test.js
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  fetchMemeContent,
+  searchMemes,
+  validateSearchResponse
+} from "../lib/api-client.js";
+import { safeFilename } from "../lib/filename.js";
+import { loadSettings, normalizeSettings, saveSettings } from "../lib/settings.js";
+import {
+  hostPermissionPattern,
+  normalizeBaseUrl,
+  resolveApiUrl
+} from "../lib/url.js";
+
+const conformanceFixtures = JSON.parse(
+  await readFile(
+    new URL("../../shared/search-response-conformance.json", import.meta.url),
+    "utf8"
+  )
+);
+
+test("shared search response conformance fixtures", () => {
+  for (const fixture of conformanceFixtures.valid) {
+    assert.doesNotThrow(
+      () => validateSearchResponse(fixture.payload, "http://127.0.0.1:3000"),
+      fixture.name
+    );
+  }
+
+  for (const fixture of conformanceFixtures.invalid) {
+    assert.throws(
+      () => validateSearchResponse(fixture.payload, "http://127.0.0.1:3000"),
+      /unexpected response|unsafe media URL/,
+      fixture.name
+    );
+  }
+});
+
+test("normalizes supported loopback origins", () => {
+  assert.equal(normalizeBaseUrl(" http://127.0.0.1:3000/ "), "http://127.0.0.1:3000");
+  assert.equal(normalizeBaseUrl("http://localhost:3100"), "http://localhost:3100");
+  assert.equal(hostPermissionPattern("http://127.0.0.1:3000"), "http://127.0.0.1/*");
+});
+
+test("rejects non-loopback, HTTPS, credentials, and paths", () => {
+  assert.throws(() => normalizeBaseUrl("http://192.168.1.5:3000"), /only connects/);
+  assert.throws(() => normalizeBaseUrl("https://localhost:3000"), /only connects/);
+  assert.throws(() => normalizeBaseUrl("http://person:secret@localhost:3000"), /cannot include/);
+  assert.throws(() => normalizeBaseUrl("http://localhost:3000/app"), /without a path/);
+});
+
+test("keeps server-provided media URLs on the configured API origin", () => {
+  assert.equal(
+    resolveApiUrl("http://127.0.0.1:3000", "/api/v1/memes/7/content").href,
+    "http://127.0.0.1:3000/api/v1/memes/7/content"
+  );
+  assert.throws(
+    () => resolveApiUrl("http://127.0.0.1:3000", "https://example.com/meme.jpg"),
+    /unsafe media URL/
+  );
+  assert.throws(
+    () => resolveApiUrl("http://127.0.0.1:3000", "/admin/export"),
+    /unexpected media URL/
+  );
+  assert.throws(
+    () => resolveApiUrl(
+      "http://127.0.0.1:3000",
+      "/api/v1/memes/7/content?next=https://example.com"
+    ),
+    /unexpected media URL/
+  );
+});
+
+test("search sends a bearer token and bounded query parameters", async () => {
+  let captured;
+  const fakeFetch = async (url, options) => {
+    captured = { url, options };
+    return new Response(JSON.stringify({
+      data: [{
+        id: 7,
+        filename: "incident.jpg",
+        description: "An incident",
+        tags: ["work"],
+        media_type: "image/jpeg",
+        content_url: "/api/v1/memes/7/content"
+      }],
+      meta: {
+        query: "production incident",
+        mode: "keyword",
+        tags: [],
+        limit: 4,
+        count: 1
+      }
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  };
+
+  const response = await searchMemes({
+    baseUrl: "http://127.0.0.1:3000",
+    token: "ms_example",
+    query: " production incident ",
+    mode: "keyword",
+    limit: 4
+  }, fakeFetch);
+
+  assert.equal(captured.options.headers.Authorization, "Bearer ms_example");
+  assert.equal(captured.options.headers.Accept, "application/json");
+  assert.equal(captured.options.redirect, "error");
+  assert.equal(captured.url.searchParams.get("q"), "production incident");
+  assert.equal(captured.url.searchParams.get("mode"), "keyword");
+  assert.equal(captured.url.searchParams.get("limit"), "4");
+  assert.equal(response.data[0].id, 7);
+});
+
+test("search validates inputs before making a request", async () => {
+  const neverFetch = () => assert.fail("fetch should not be called");
+
+  await assert.rejects(
+    searchMemes({ baseUrl: "http://localhost:3000", token: "x", query: "", limit: 8 }, neverFetch),
+    /Enter a search query/
+  );
+  await assert.rejects(
+    searchMemes({ baseUrl: "http://localhost:3000", token: "x", query: "hi", limit: 21 }, neverFetch),
+    /between 1 and 20/
+  );
+});
+
+test("content requests remain authenticated and require an image response", async () => {
+  let capturedOptions;
+  const imageFetch = async (_url, options) => {
+    capturedOptions = options;
+    return new Response(new Blob(["image"], { type: "image/png" }), {
+      status: 200,
+      headers: { "Content-Type": "image/png" }
+    });
+  };
+
+  const blob = await fetchMemeContent({
+    baseUrl: "http://127.0.0.1:3000",
+    token: "ms_media",
+    contentUrl: "/api/v1/memes/9/content"
+  }, imageFetch);
+
+  assert.equal(capturedOptions.headers.Authorization, "Bearer ms_media");
+  assert.equal(capturedOptions.headers.Accept, "image/*,application/octet-stream");
+  assert.equal(capturedOptions.redirect, "error");
+  assert.equal(blob.type, "image/png");
+
+  await assert.rejects(
+    fetchMemeContent({
+      baseUrl: "http://127.0.0.1:3000",
+      token: "ms_media",
+      contentUrl: "/api/v1/memes/9/content"
+    }, async () => new Response("no", { status: 200, headers: { "Content-Type": "text/plain" } })),
+    /non-image/
+  );
+});
+
+test("API errors use a safe status-specific message", async () => {
+  await assert.rejects(
+    searchMemes({
+      baseUrl: "http://127.0.0.1:3000",
+      token: "bad",
+      query: "hello",
+      mode: "keyword",
+      limit: 8
+    }, async () => new Response("", { status: 401 })),
+    /token is missing or invalid/
+  );
+});
+
+test("API errors redact reflected tokens and reject redirects", async () => {
+  await assert.rejects(
+    searchMemes({
+      baseUrl: "http://127.0.0.1:3000",
+      token: "ms_reflected_secret",
+      query: "hello",
+      mode: "keyword",
+      limit: 8
+    }, async () => new Response(JSON.stringify({
+      error: { message: "bad token ms_reflected_secret" }
+    }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" }
+    })),
+    (error) => {
+      assert.match(error.message, /\[REDACTED\]/);
+      assert.doesNotMatch(error.message, /ms_reflected_secret/);
+      return true;
+    }
+  );
+
+  await assert.rejects(
+    searchMemes({
+      baseUrl: "http://127.0.0.1:3000",
+      token: "ms_token",
+      query: "hello",
+      mode: "keyword",
+      limit: 8
+    }, async () => ({ ok: true, redirected: true })),
+    /unexpected redirect/
+  );
+});
+
+test("search and media fetches preserve abort cancellation", async () => {
+  const controller = new AbortController();
+  const abortingFetch = async (_url, options) => new Promise((_resolve, reject) => {
+    options.signal.addEventListener("abort", () => reject(
+      new DOMException("cancelled", "AbortError")
+    ), { once: true });
+  });
+
+  const search = searchMemes({
+    baseUrl: "http://127.0.0.1:3000",
+    token: "ms_token",
+    query: "hello",
+    signal: controller.signal
+  }, abortingFetch);
+  const media = fetchMemeContent({
+    baseUrl: "http://127.0.0.1:3000",
+    token: "ms_token",
+    contentUrl: "/api/v1/memes/7/content",
+    signal: controller.signal
+  }, abortingFetch);
+
+  controller.abort();
+
+  await assert.rejects(search, { name: "AbortError" });
+  await assert.rejects(media, { name: "AbortError" });
+});
+
+test("search rejects invalid JSON, invalid fields, and unsafe content URLs", async () => {
+  const input = {
+    baseUrl: "http://127.0.0.1:3000",
+    token: "ms_token",
+    query: "hello",
+    mode: "keyword",
+    limit: 8
+  };
+
+  await assert.rejects(
+    searchMemes(input, async () => new Response("{bad", { status: 200 })),
+    /invalid JSON/
+  );
+  await assert.rejects(
+    searchMemes(input, async () => new Response(JSON.stringify({
+      data: [{ id: "seven" }],
+      meta: {}
+    }), { status: 200, headers: { "Content-Type": "application/json" } })),
+    /unexpected response/
+  );
+  await assert.rejects(
+    searchMemes(input, async () => new Response(JSON.stringify({
+      data: [{
+        id: 7,
+        filename: "incident.jpg",
+        description: null,
+        tags: [],
+        media_type: "image/jpeg",
+        content_url: "https://attacker.example/steal"
+      }],
+      meta: {
+        query: "hello",
+        mode: "keyword",
+        tags: [],
+        limit: 8,
+        count: 1
+      }
+    }), { status: 200, headers: { "Content-Type": "application/json" } })),
+    /unsafe media URL/
+  );
+});
+
+test("settings validate before storage and round trip only the expected keys", async () => {
+  assert.throws(
+    () => normalizeSettings({ baseUrl: "http://127.0.0.1:3000", token: "" }),
+    /Enter an API token/
+  );
+
+  const values = {};
+  const storage = {
+    async get(keys) {
+      assert.deepEqual(keys, ["baseUrl", "token"]);
+      return values;
+    },
+    async set(update) {
+      Object.assign(values, update);
+    }
+  };
+
+  const saved = await saveSettings({
+    baseUrl: "http://localhost:3000/",
+    token: " ms_local "
+  }, storage);
+  assert.deepEqual(saved, {
+    baseUrl: "http://localhost:3000",
+    token: "ms_local"
+  });
+  assert.deepEqual(await loadSettings(storage), saved);
+});
+
+test("download filenames cannot escape directories or become dot entries", () => {
+  assert.equal(safeFilename("../../secret.gif"), "secret.gif");
+  assert.equal(safeFilename(".."), "meme");
+  assert.equal(safeFilename("bad/name\u0000.gif"), "name_.gif");
+});

--- a/integrations/browser-extension/test/clipboard.test.js
+++ b/integrations/browser-extension/test/clipboard.test.js
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  copyOriginalToClipboard,
+  writePngToClipboard
+} from "../lib/clipboard.js";
+
+test("starts the clipboard write before asynchronous PNG conversion resolves", async () => {
+  const events = [];
+  let resolvePng;
+  const pngPromise = new Promise((resolve) => {
+    resolvePng = resolve;
+  });
+
+  class FakeClipboardItem {
+    constructor(data) {
+      events.push("construct");
+      this.data = data;
+    }
+  }
+
+  const clipboard = {
+    write(items) {
+      events.push("write");
+      assert.equal(items.length, 1);
+      assert.equal(items[0].data["image/png"], pngPromise);
+      return items[0].data["image/png"].then(() => {
+        events.push("resolved");
+      });
+    }
+  };
+
+  const writePromise = writePngToClipboard(pngPromise, {
+    clipboard,
+    ClipboardItemConstructor: FakeClipboardItem
+  });
+
+  assert.deepEqual(events, ["construct", "write"]);
+
+  resolvePng(new Blob(["png"], { type: "image/png" }));
+  await writePromise;
+
+  assert.deepEqual(events, ["construct", "write", "resolved"]);
+});
+
+test("fails clearly when image clipboard support is unavailable", () => {
+  assert.throws(
+    () => writePngToClipboard(Promise.resolve(new Blob()), {
+      clipboard: {},
+      ClipboardItemConstructor: undefined
+    }),
+    /Image copying is not available/
+  );
+});
+
+test("starts clipboard permission work before explicit-action media fetch resolves", async () => {
+  const events = [];
+  let resolveOriginal;
+  const originalPromise = new Promise((resolve) => {
+    resolveOriginal = resolve;
+  });
+  const session = {
+    signal: new AbortController().signal,
+    async runOriginal(loadBlob, useBlob) {
+      const blob = await loadBlob(this.signal);
+      return useBlob(blob, this.signal);
+    }
+  };
+  class FakeClipboardItem {
+    constructor(data) {
+      events.push("construct");
+      this.data = data;
+    }
+  }
+  const clipboard = {
+    write(items) {
+      events.push("write");
+      return items[0].data["image/png"];
+    }
+  };
+
+  const copy = copyOriginalToClipboard(
+    session,
+    async () => {
+      events.push("fetch");
+      return originalPromise;
+    },
+    {
+      clipboard,
+      ClipboardItemConstructor: FakeClipboardItem,
+      convertToPng: async (blob) => {
+        events.push("convert");
+        return blob;
+      }
+    }
+  );
+
+  assert.deepEqual(events, ["fetch", "construct", "write"]);
+  resolveOriginal(new Blob(["png"], { type: "image/png" }));
+  await copy;
+  assert.deepEqual(events, ["fetch", "construct", "write", "convert"]);
+});

--- a/integrations/browser-extension/test/image-conversion.test.js
+++ b/integrations/browser-extension/test/image-conversion.test.js
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { convertToPng } from "../lib/image-conversion.js";
+
+test("converts an animated GIF preview to one still PNG frame", async () => {
+  let bitmapClosed = false;
+  let drawnBitmap;
+  const png = new Blob(["still frame"], { type: "image/png" });
+  const bitmap = {
+    width: 320,
+    height: 200,
+    close() {
+      bitmapClosed = true;
+    }
+  };
+  const canvas = {
+    getContext() {
+      return {
+        drawImage(value) {
+          drawnBitmap = value;
+        }
+      };
+    },
+    toBlob(callback, type) {
+      assert.equal(type, "image/png");
+      callback(png);
+    }
+  };
+
+  const result = await convertToPng(
+    new Blob(["GIF89a"], { type: "image/gif" }),
+    new AbortController().signal,
+    {
+      createImageBitmap: async () => bitmap,
+      createCanvas: () => canvas
+    }
+  );
+
+  assert.equal(result, png);
+  assert.equal(drawnBitmap, bitmap);
+  assert.equal(canvas.width, 320);
+  assert.equal(canvas.height, 200);
+  assert.equal(bitmapClosed, true);
+});
+
+test("closes decoded preview resources when cancellation wins", async () => {
+  const controller = new AbortController();
+  let bitmapClosed = false;
+  const bitmap = {
+    width: 1,
+    height: 1,
+    close() {
+      bitmapClosed = true;
+    }
+  };
+
+  const conversion = convertToPng(
+    new Blob(["GIF89a"], { type: "image/gif" }),
+    controller.signal,
+    {
+      createImageBitmap: async () => {
+        controller.abort();
+        return bitmap;
+      },
+      createCanvas: () => assert.fail("cancelled conversion must not allocate a canvas")
+    }
+  );
+
+  await assert.rejects(conversion, { name: "AbortError" });
+  assert.equal(bitmapClosed, true);
+});

--- a/integrations/browser-extension/test/manifest.test.js
+++ b/integrations/browser-extension/test/manifest.test.js
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const manifest = JSON.parse(
+  await readFile(new URL("../manifest.json", import.meta.url), "utf8")
+);
+
+test("manifest is a narrow unpacked Chromium MV3 surface", () => {
+  assert.equal(manifest.manifest_version, 3);
+  assert.deepEqual(manifest.permissions.sort(), ["clipboardWrite", "storage"]);
+  assert.deepEqual(manifest.optional_host_permissions.sort(), [
+    "http://127.0.0.1/*",
+    "http://localhost/*"
+  ]);
+  assert.equal(
+    manifest.content_security_policy.extension_pages,
+    "script-src 'self'; object-src 'self'"
+  );
+  assert.equal(manifest.background, undefined);
+  assert.equal(manifest.host_permissions, undefined);
+  assert.equal(manifest.update_url, undefined);
+});

--- a/integrations/browser-extension/test/media-work-session.test.js
+++ b/integrations/browser-extension/test/media-work-session.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { MediaWorkSession } from "../lib/media-work-session.js";
+
+test("popup has no automatic preview or viewport media path", async () => {
+  const popupPath = fileURLToPath(new URL("../popup.js", import.meta.url));
+  const popupHtmlPath = fileURLToPath(new URL("../popup.html", import.meta.url));
+  const [source, html] = await Promise.all([
+    readFile(popupPath, "utf8"),
+    readFile(popupHtmlPath, "utf8")
+  ]);
+
+  assert.doesNotMatch(source, /loadPreview|IntersectionObserver|previewLoader/);
+  assert.doesNotMatch(html, /preview-frame|<img/i);
+  assert.match(html, /Media loads only after Copy or Download/);
+});
+
+test("cancels stale original actions", async () => {
+  const session = new MediaWorkSession();
+  let copyActionRan = false;
+  let downloadActionRan = false;
+  const abortableLoader = (signal) => new Promise((_resolve, reject) => {
+    signal.addEventListener("abort", () => reject(
+      new DOMException("cancelled", "AbortError")
+    ), { once: true });
+  });
+
+  const copy = session.runOriginal(
+    abortableLoader,
+    async () => {
+      copyActionRan = true;
+    }
+  );
+  const download = session.runOriginal(
+    abortableLoader,
+    async () => {
+      downloadActionRan = true;
+    }
+  );
+
+  session.cancel();
+
+  await assert.rejects(copy, { name: "AbortError" });
+  await assert.rejects(download, { name: "AbortError" });
+  assert.equal(copyActionRan, false);
+  assert.equal(downloadActionRan, false);
+  assert.equal(session.signal.aborted, true);
+});
+
+test("revokes every action object URL on rerender or unload", async () => {
+  const created = [];
+  const revoked = [];
+  const session = new MediaWorkSession({
+    createObjectURL(blob) {
+      const url = `blob:${created.length + 1}`;
+      created.push({ blob, url });
+      return url;
+    },
+    revokeObjectURL(url) {
+      revoked.push(url);
+    }
+  });
+
+  const firstActionUrl = session.retainObjectUrl(new Blob(["download-one"]));
+  const secondActionUrl = session.retainObjectUrl(new Blob(["download-two"]));
+  assert.deepEqual([firstActionUrl, secondActionUrl], ["blob:1", "blob:2"]);
+
+  session.cancel();
+
+  assert.deepEqual(revoked.sort(), ["blob:1", "blob:2"]);
+  assert.equal(session.objectUrls.size, 0);
+});
+
+test("original loader runs only inside an explicit action", async () => {
+  const session = new MediaWorkSession();
+  let fetchCount = 0;
+  const loadOriginal = async () => {
+    fetchCount += 1;
+    return new Blob(["selected"]);
+  };
+
+  const resultLoaders = Array.from({ length: 20 }, () => loadOriginal);
+  assert.equal(fetchCount, 0, "rendering 20 metadata cards must not fetch media");
+
+  await session.runOriginal(resultLoaders[13], async () => {});
+  assert.equal(fetchCount, 1, "one explicit action fetches only its selected result");
+});

--- a/integrations/shared/search-response-conformance.json
+++ b/integrations/shared/search-response-conformance.json
@@ -1,0 +1,115 @@
+{
+  "valid": [
+    {
+      "name": "required v1 fields",
+      "payload": {
+        "data": [
+          {
+            "id": 42,
+            "filename": "ship-it.gif",
+            "description": "A celebratory launch",
+            "tags": ["deploy", "success"],
+            "media_type": "image/gif",
+            "content_url": "/api/v1/memes/42/content"
+          }
+        ],
+        "meta": {
+          "query": "ship it",
+          "mode": "keyword",
+          "tags": [],
+          "limit": 10,
+          "count": 1
+        }
+      }
+    },
+    {
+      "name": "additive response fields",
+      "payload": {
+        "data": [
+          {
+            "id": 7,
+            "filename": "incident.jpg",
+            "description": null,
+            "tags": ["work"],
+            "media_type": "image/jpeg",
+            "content_url": "/api/v1/memes/7/content",
+            "future_meme_field": "clients ignore this"
+          }
+        ],
+        "meta": {
+          "query": "incident",
+          "mode": "vector",
+          "tags": ["work"],
+          "limit": 5,
+          "count": 1,
+          "future_meta_field": {
+            "cursor": "opaque"
+          }
+        },
+        "future_top_level_field": true
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "name": "missing required meta count",
+      "payload": {
+        "data": [],
+        "meta": {
+          "query": "ship it",
+          "mode": "keyword",
+          "tags": [],
+          "limit": 10
+        }
+      }
+    },
+    {
+      "name": "invalid meta tags type",
+      "payload": {
+        "data": [],
+        "meta": {
+          "query": "ship it",
+          "mode": "keyword",
+          "tags": "deploy",
+          "limit": 10,
+          "count": 0
+        }
+      }
+    },
+    {
+      "name": "boolean is not an integer count",
+      "payload": {
+        "data": [],
+        "meta": {
+          "query": "ship it",
+          "mode": "keyword",
+          "tags": [],
+          "limit": 10,
+          "count": true
+        }
+      }
+    },
+    {
+      "name": "unsafe absolute content URL",
+      "payload": {
+        "data": [
+          {
+            "id": 42,
+            "filename": "ship-it.gif",
+            "description": null,
+            "tags": [],
+            "media_type": "image/gif",
+            "content_url": "http://localhost:9999/steal"
+          }
+        ],
+        "meta": {
+          "query": "ship it",
+          "mode": "keyword",
+          "tags": [],
+          "limit": 10,
+          "count": 1
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add an experimental Chromium popup for searching a local Meme Search collection
- render metadata-only results and fetch media only after an explicit Copy or Download action
- keep the default and permitted API origin loopback-only
- document unpacked installation, token setup, support boundaries, and removal

## Support boundary

This is intentionally **experimental**, **Chromium-only**, **unpacked**, **loopback-only**, and **not published to an extension store**. It remains in this repository while the API and UX stabilize; extraction can be reconsidered once it needs an independent release cadence, store publication, or broader browser support.

## Security

- no background worker or remote code
- no broad host permissions; only `localhost` and `127.0.0.1`
- no automatic media requests during search, rendering, or scrolling
- the bearer token is stored in `chrome.storage.local` and sent only to the validated loopback API origin
- redirects are rejected and token-bearing failures are redacted
- no `innerHTML`-style rendering sinks or token logging

Do not expose Meme Search directly to a public network to use this extension.

## Verification

- `npm test` — 23 passed
- `npm run check` — passed
- manifest JSON parse — passed
- `npm audit --audit-level=high` — 0 vulnerabilities
- static security/scope scans — passed
- prior real unpacked-Chromium smoke for the identical runtime tree: 0 media requests before action, 1 after Copy, 2 after Download

A fresh automated visit to `chrome://extensions` was blocked by the browser-control security policy, so this PR does not overstate that as a newly repeated smoke. The only change from the previously browser-smoked runtime tree is the dependency-free `package-lock.json`.