### PR TITLE
Add local Search API CLI and relevance tooling

### DIFF
--- a/.github/workflows/pro-app-test.yml
+++ b/.github/workflows/pro-app-test.yml
@@ -11,11 +11,17 @@ on:
       - "playwright.config.ts"
       - "playwright/**"
       - "playwright-docker/**"
-      - "integrations/browser-extension/**"
+      - "integrations/**"
+      - "docs/search-api*"
       - "meme_search/meme_search_app/**"
       - ".github/workflows/pro-app-test.yml"
       - "README.md"
+      - "SECURITY.md"
+      - ".env.example"
+      - "docker-compose.yml"
+      - "docker-compose-local-build.yml"
       - "scripts/validate_discord_link.sh"
+      - "scripts/run_all_ci_tests.sh"
       - "!meme_search/meme_search_app/**/*.md"
       - "!meme_search/meme_search_app/**/LICENSE"
   push:
@@ -27,11 +33,17 @@ on:
       - "playwright.config.ts"
       - "playwright/**"
       - "playwright-docker/**"
-      - "integrations/browser-extension/**"
+      - "integrations/**"
+      - "docs/search-api*"
       - "meme_search/meme_search_app/**"
       - ".github/workflows/pro-app-test.yml"
       - "README.md"
+      - "SECURITY.md"
+      - ".env.example"
+      - "docker-compose.yml"
+      - "docker-compose-local-build.yml"
       - "scripts/validate_discord_link.sh"
+      - "scripts/run_all_ci_tests.sh"
       - "!meme_search/meme_search_app/**/*.md"
       - "!meme_search/meme_search_app/**/LICENSE"
 
@@ -93,25 +105,43 @@ jobs:
         working-directory: ./meme_search/meme_search_app
         run: bin/importmap audit
 
-  browser_extension:
+  integration_clients:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
           node-version: "20"
 
+      - name: Install root contract dependencies
+        run: npm ci
+
+      - name: Validate OpenAPI 3.1 contract
+        run: npm run contract:openapi
+
+      - name: Audit root dependencies
+        run: npm audit --audit-level=high
+
+      - name: Test local CLI
+        working-directory: ./integrations/cli
+        run: |
+          python -m unittest discover -v
+          python -m py_compile meme_search_cli.py meme-search
+
       - name: Test browser extension
         working-directory: ./integrations/browser-extension
         run: |
-          npm ci
           npm test
           npm run check
-          npm audit --audit-level=high
           node -e 'JSON.parse(require("fs").readFileSync("manifest.json", "utf8")); console.log("manifest ok")'
           ! rg 'innerHTML|outerHTML|insertAdjacentHTML' . --glob '*.js'
           ! rg --pcre2 'https?://(?!127\.0\.0\.1|localhost)' . --glob '*.js' --glob '!test/**'
@@ -192,6 +222,30 @@ jobs:
           COVERAGE: true
         run: bin/rails test test/controllers
 
+      - name: Run service tests
+        working-directory: ./meme_search/meme_search_app
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          COVERAGE: true
+        run: bin/rails test test/services
+
+      - name: Run API contract tests
+        working-directory: ./meme_search/meme_search_app
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          COVERAGE: true
+        run: bin/rails test test/contracts
+
+      - name: Run database and migration tests
+        working-directory: ./meme_search/meme_search_app
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          COVERAGE: true
+        run: bin/rails test test/db
+
       - name: Run channel tests
         working-directory: ./meme_search/meme_search_app
         env:
@@ -199,6 +253,14 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           COVERAGE: true
         run: bin/rails test test/channels
+
+      - name: Run Rake task tests
+        working-directory: ./meme_search/meme_search_app
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          COVERAGE: true
+        run: bin/rails test test/tasks
 
   playwright_tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ docker compose up
 
 Open <http://localhost:3000>, then drag, drop, or paste images on the upload page. The first local description generation downloads the selected model, so it takes longer than later generations.
 
-The web UI binds to `127.0.0.1` by default because Meme Search does not currently include authentication. To access it from another device on a trusted network, copy `.env.example` to `.env` and set `APP_BIND_ADDRESS=0.0.0.0`. Do not expose an unauthenticated instance directly to the internet; use an authenticated reverse proxy or VPN.
+The web UI binds to `127.0.0.1` by default because it does not include user
+authentication. Official support is loopback-only for API v1 and the included
+clients. API bearer tokens protect only the versioned integration
+endpoints; they do not protect the web UI or settings. Direct public exposure
+is unsupported. Proxy/VPN operation is advanced and unsupported; its
+authentication, TLS, and network controls are entirely the operator's
+responsibility.
 
 A table of contents for the remainder of this README:
 
@@ -36,6 +42,7 @@ A table of contents for the remainder of this README:
   - [Installation instructions](#installation-instructions)
   - [Time to first generation / downloading models](#time-to-first-generation--downloading-models)
   - [Index your memes](#index-your-memes)
+  - [Search API and local integrations](#search-api-and-local-integrations)
   - [Custom bind address and app port](#custom-bind-address-and-app-port)
   - [Building the app locally with Docker](#building-the-app-locally-with-docker)
   - [Running tests](#running-tests)
@@ -308,6 +315,42 @@ Now restart the app, and register the `new_memes` via the UX by traversing to th
 
 Once registered in the app, your memes are ready for indexing / tagging / etc.,!
 
+### Search API and local integrations
+
+Meme Search provides a token-authenticated, read-only `/api/v1` for search,
+metadata, and authorized media streaming. The repository also includes a local
+CLI, a small unpacked browser-extension popup, and a UI-independent relevance
+evaluator.
+
+Create and revoke scoped client credentials under **Settings → API tokens**.
+The raw value is shown once with a copy control and manual-selection fallback;
+refresh and back navigation do not redisplay it. Optional browser-local expiry
+times are converted to exact timezone-aware instants before submission.
+Rails tasks remain available for Docker, native automation, and recovery.
+API v1 is stable and additive, permanently read-only, and reserves breaking
+changes for `/api/v2`.
+
+See [Search API and local integrations](docs/search-api.md) for token setup,
+upgrade/migration steps, endpoint examples, compatibility and security
+boundaries, included clients, troubleshooting, and guidance for community-built
+integrations. Optional relevance datasets use explicit stable IDs or normalized
+library-relative paths; ambiguous filename-only v1 fixtures are rejected.
+
+For the complete local equivalent of the required test workflow, install the
+repository dependencies, make sure Docker is available, and run `npm test`.
+When `DATABASE_URL` is unset, the runner creates a temporary pgvector container
+on a Docker-assigned port bound only to `127.0.0.1`; native Rails is pointed at
+that exact test database, and only that runner-owned container is removed on
+exit or interruption. To use an existing PostgreSQL 17 + pgvector server
+instead, supply `DATABASE_URL`; the runner never replaces or stops it.
+
+The runner includes Rails model/controller/service/contract/database/channel/
+task tests, security and static checks, the Python service,
+OpenAPI validation, both local clients, dependency/type checks, and Playwright.
+Focused `test:rails` and `test:python` aliases intentionally run only their
+named component. The production Compose database remains internal-only and is
+not published for native tests.
+
 ### Model downloads
 
 The image-to-text models used to auto generate descriptions for your memes are all open source, and vary in size.
@@ -319,11 +362,23 @@ Easily customize the app's port to more easily use the it with tools like [Unrai
 To customize the bind address or main app port, copy `.env.example` to `.env` in the repository root and adjust:
 
 ```sh
-APP_BIND_ADDRESS=127.0.0.1 # use 0.0.0.0 only on a trusted network
+APP_BIND_ADDRESS=127.0.0.1
 APP_PORT=3000
 ```
 
 This value is automatically detected and loaded into each service via the Compose files. The Postgres service is only exposed on Docker's internal network, so app containers always talk to it at `meme-search-db:5432`.
+
+Changing `APP_BIND_ADDRESS` away from loopback is advanced and unsupported. A
+trusted LAN is not an authentication boundary, and API tokens do not protect
+the web UI or settings. If an operator chooses to use a private VPN or
+authenticated TLS reverse proxy, that operator owns the full configuration and
+security review. Direct public exposure remains unsupported.
+
+Rails rejects unrecognized `Host` headers to prevent DNS rebinding. Advanced
+reverse proxies must opt an exact hostname into the comma-separated
+`MEME_SEARCH_ALLOWED_HOSTS` setting. Wildcards, URLs, ports, and CIDR ranges are
+rejected. Allowing a host does not authenticate the web UI or make non-loopback
+exposure supported.
 
 ### Building the app locally with Docker
 
@@ -359,7 +414,10 @@ Tests can then be run as
 bash run_tests.sh
 ```
 
-When doing this ensure you have an available Postgres instance running locally on port `5432`.
+When invoking this app-local script directly, ensure PostgreSQL with pgvector
+is available through the Rails database configuration. The root `npm test`
+runner instead provisions an isolated loopback-only test database unless
+`DATABASE_URL` is supplied.
 
 Run linting tests on the `/app` subdirectory as
 

--- a/docs/search-api.md
+++ b/docs/search-api.md
@@ -6,11 +6,10 @@ the web UI and stream media through an authenticated endpoint. They never need
 PostgreSQL credentials, Docker-network access, database schema knowledge, or
 filesystem paths.
 
-The API does not add authentication to the web UI. Official support for API v1
-is loopback-only; keep the default loopback binding. Direct public exposure is
-unsupported. Proxy/VPN operation is advanced and unsupported; its
-authentication, TLS, ingress, host-authorization, and secret management are
-entirely the operator's responsibility.
+The API does not add authentication to the web UI. Official support is loopback-only for API v1 and the included clients; keep the default loopback
+binding. Direct public exposure is unsupported. Proxy/VPN operation is advanced
+and unsupported; its authentication, TLS, ingress, host-authorization, and
+secret management are entirely the operator's responsibility.
 
 Rails also enforces an exact Host-header allowlist to prevent DNS rebinding.
 Loopback and required Docker-internal names work without configuration. An
@@ -38,14 +37,14 @@ Rails tasks provide automation and recovery paths. For Docker:
 
 ```sh
 docker compose exec meme_search bin/rails api_tokens:create \
-  NAME="My integration" SCOPES="search:read,media:read"
+  NAME="Local CLI" SCOPES="search:read,media:read"
 ```
 
 For a native Rails checkout, run the same task from
 `meme_search/meme_search_app`:
 
 ```sh
-bin/rails api_tokens:create NAME="My integration" SCOPES="search:read,media:read"
+bin/rails api_tokens:create NAME="Local CLI" SCOPES="search:read,media:read"
 ```
 
 Optional `EXPIRES_AT` must be an ISO-8601 timestamp with a timezone, such as
@@ -160,9 +159,31 @@ Errors use `{"error":{"code":"...","message":"..."}}`:
 | `429` | this authenticated token exceeded 60 searches per minute |
 
 The machine-readable contract is available in
-[`search-api-openapi.yml`](search-api-openapi.yml). Contract tests compare its
-routes, bounds, response schemas, scopes, errors, and media types to the Rails
-implementation.
+[`search-api-openapi.yml`](search-api-openapi.yml).
+After installing root dependencies, validate the OpenAPI 3.1 document locally
+without network access:
+
+```sh
+npm run contract:openapi
+```
+
+The CLI and extension test suites both consume
+`integrations/shared/search-response-conformance.json`, including an
+additive-field fixture, so their required-field checks stay aligned.
+
+## Included clients
+
+- [`integrations/cli`](../integrations/cli/README.md) provides dependency-free
+  Python search and fetch commands. Downloads verify a declared content length,
+  refuse concurrent no-force clobbers atomically, and replace atomically only
+  when `--force` is explicit.
+- [`integrations/browser-extension`](../integrations/browser-extension/README.md)
+  provides a small unpacked Chromium popup for loopback search. Result cards
+  remain metadata-only because API v1 has no bounded thumbnail representation.
+  It fetches media only after an explicit copy or download and cancels stale
+  action requests on a replacement search or popup unload.
+
+Neither client is published to a package or extension store.
 
 ## Upgrade and migration
 
@@ -191,6 +212,68 @@ bin/rails db:migrate:status
 A fresh database receives the same schema through `db:prepare`; an existing
 database receives the forward-only `api_tokens` migration. The migration adds
 no user/library ownership model and does not authenticate existing web routes.
+
+## Relevance benchmark
+
+The included `meme_search/meme_search_app/benchmark/search_relevance.yml` is a
+replace-me template, not a canonical dataset or a search-quality claim. Copy it
+outside the repository, set `template_only: false`, replace the samples with
+stable IDs or normalized paths relative to `public/memes`, and run:
+
+```yaml
+version: 2
+template_only: false
+cases:
+  - query: "production incident"
+    mode: keyword
+    expected:
+      - path: "work/reactions/incident.gif"
+      - id: 123
+```
+
+Each expected entry must contain exactly one positive `id` or one `path`.
+Paths include the registered library directory and filename; bare filenames
+and v1 datasets are rejected because different directories may contain the
+same filename. Then run:
+
+```sh
+cd meme_search/meme_search_app
+bin/rails search:relevance DATASET=/path/to/search_relevance.yml K=10
+```
+
+The JSON report contains per-query rankings plus hit rate, mean reciprocal rank
+(MRR), and mean recall at K. Because the evaluator calls the shared query
+service directly, it measures search behavior without Turbo, templates, or
+browser state.
+
+This tool is optional and non-gating in v1. The repository does not ship a
+canonical relevance dataset, a regression threshold, or CI/release enforcement.
+Choosing and maintaining canonical data and quality thresholds is explicitly
+deferred to v2. Never commit filenames, descriptions, images, or embeddings
+from a private collection.
+
+## Local CI parity
+
+From the repository root, `npm test` runs the required workflow suite families:
+Rails security/static checks and model, controller, service, contract,
+database, channel, and Rake-task tests; the Python service; the
+OpenAPI validator; root dependency and TypeScript checks; CLI and extension
+tests/static checks; and Playwright. It requires installed root/Ruby/Python
+dependencies, Docker, and a Chromium available to Playwright. When
+`DATABASE_URL` is unset, the runner starts its own ephemeral
+`pgvector/pgvector:pg17` container, publishes its database only to
+`127.0.0.1` on a Docker-assigned port, and points native Rails at that exact
+endpoint. It removes only that runner-owned container on normal exit, failure,
+or interruption. The production Compose database remains internal-only.
+
+Set `DATABASE_URL` to use a caller-managed PostgreSQL 17 + pgvector test
+server. The runner preserves that value, creates no database container, and
+never stops the caller-managed server.
+
+`npm run test:ci:skip-e2e` skips only Playwright. The `test:rails` and
+`test:python` scripts are explicitly focused shortcuts and are not CI-parity
+commands. Every required suite records its own failure, and the runner exits
+nonzero if any required suite fails.
 
 ## Community integration contract
 
@@ -236,3 +319,6 @@ the app public merely to connect a platform integration.
 - Connection refused: confirm the app is running at
   `http://127.0.0.1:3000`. Official support does not require changing the bind
   address.
+- CLI or extension errors: follow their linked README and run their local
+  contract tests. Interactive extension permission/clipboard/download behavior
+  is covered by its manual smoke checklist, not claimed by Node tests.

--- a/integrations/cli/README.md
+++ b/integrations/cli/README.md
@@ -1,0 +1,156 @@
+# Meme Search CLI
+
+A dependency-free Python 3 client for searching a Meme Search collection and
+downloading a result. It uses the authenticated, read-only `/api/v1` interface;
+it never connects to PostgreSQL or the internal image-to-text service.
+
+## Requirements
+
+- Python 3.10 or newer
+- A running Meme Search instance with the v1 API enabled
+- An API token with `search:read`, plus `media:read` when using `fetch`
+
+Official support is loopback-only. Keep the web app at its default loopback
+binding: API tokens do not authenticate the web UI or settings, and direct
+public exposure is unsupported. The CLI refuses to send a token over plain
+HTTP to a non-loopback host.
+
+## Setup
+
+Create a token from **Settings → API tokens**, or use the Rails task.
+
+For Docker, from the repository root:
+
+```sh
+docker compose exec meme_search bin/rails api_tokens:create \
+  NAME="Local CLI" SCOPES="search:read,media:read"
+```
+
+For a native checkout:
+
+```sh
+cd meme_search/meme_search_app
+bin/rails api_tokens:create \
+  NAME="Local CLI" SCOPES="search:read,media:read"
+cd ../..
+```
+
+Copy the raw token immediately; Meme Search stores only its digest. Then export
+it from the shell in which you will run the CLI:
+
+```sh
+export MEME_SEARCH_API_TOKEN='ms_your_token_here'
+export MEME_SEARCH_URL='http://127.0.0.1:3000' # optional; this is the default
+```
+
+The token is intentionally accepted only through the environment, not a
+command-line flag, to keep it out of shell history and process listings.
+
+## Search
+
+```sh
+./integrations/cli/meme-search search 'production incident'
+./integrations/cli/meme-search search 'ship it' --mode vector --limit 5
+./integrations/cli/meme-search search 'reaction' --tag work --tag favorite
+./integrations/cli/meme-search search 'deploy' --json | jq '.data[].id'
+```
+
+Human-readable output includes each result's ID and `content_url`. `--json`
+prints the complete API response for scripts and community-built tools.
+
+For example, search with `jq` and fetch the first result:
+
+```sh
+meme_id="$(
+  ./integrations/cli/meme-search search 'ship it' --json |
+    jq -r '.data[0].id'
+)"
+./integrations/cli/meme-search fetch "$meme_id" --output ./ship-it.gif
+```
+
+## Fetch media
+
+Pass either a numeric result ID or the relative `content_url` returned by
+search:
+
+```sh
+./integrations/cli/meme-search fetch 42 --output ./ship-it.gif
+./integrations/cli/meme-search fetch /api/v1/memes/42/content -o ./ship-it.gif
+```
+
+Downloads are streamed to a same-directory temporary file and, when the server
+provides `Content-Length`, committed only after the received byte count matches.
+Without `--force`, the final create-if-absent step is atomic, so a file created
+by another process during the download is preserved. `--force` explicitly uses
+an atomic replacement. Failed or truncated downloads remove their temporary
+file, and symlink destinations are always rejected.
+
+## Configuration
+
+```text
+MEME_SEARCH_API_TOKEN   Required bearer token
+MEME_SEARCH_URL         Instance origin (default http://127.0.0.1:3000)
+--url                   Override the instance origin for one invocation
+--timeout               Request timeout in seconds (default 15)
+```
+
+Run `./integrations/cli/meme-search --help` or a subcommand's `--help` for the
+complete command reference.
+
+### Advanced networking is unsupported
+
+`https://` instance origins are accepted so an operator can use an
+authenticated TLS reverse proxy or private VPN, but that is advanced,
+unsupported configuration. The operator owns TLS validation, proxy
+authentication, ingress, host authorization, and secret handling. The CLI
+never follows authenticated redirects. Official support and automated coverage
+remain loopback-only.
+
+## Revoke or rotate a token
+
+List safe token prefixes and revoke one with either the settings page or Rails
+tasks:
+
+```sh
+# Docker
+docker compose exec meme_search bin/rails api_tokens:list
+docker compose exec meme_search bin/rails api_tokens:revoke PREFIX="ms_abcd1234"
+
+# Native, from meme_search/meme_search_app
+bin/rails api_tokens:list
+bin/rails api_tokens:revoke PREFIX="ms_abcd1234"
+```
+
+Create a replacement token before revoking an in-use client. The full raw token
+cannot be recovered after creation.
+
+## Troubleshooting
+
+- `MEME_SEARCH_API_TOKEN is required`: export the one-time raw token in the
+  current shell; do not pass it as a command-line flag.
+- `HTTP 401`: the token is missing, invalid, expired, or revoked.
+- `HTTP 403`: the token lacks `search:read` or `media:read` for that command.
+- `could not connect`: confirm Meme Search is running at `MEME_SEARCH_URL` and
+  remains reachable over loopback.
+- `plain HTTP is only allowed for loopback`: use the default loopback URL.
+  Remote HTTPS is an advanced, unsupported operator configuration.
+- `output already exists`: choose another path or intentionally add `--force`.
+- `unexpected search response` or `unexpected media type`: the server and CLI
+  contracts do not match; verify both come from the same supported release.
+
+## Tests
+
+The tests use a loopback-only fake HTTP server and make no external requests:
+
+```sh
+cd integrations/cli
+python3 -m unittest discover -v
+python3 -m py_compile meme_search_cli.py meme-search
+```
+
+For a manual smoke test against disposable local data, create a dedicated token
+and exercise: keyword and vector search; repeated `--tag`; `--json | jq`;
+fetch by ID and exact returned `content_url`; overwrite refusal and intentional
+`--force`; then revoke the token and confirm the next command returns 401. This
+real-Rails walkthrough is an acceptance step, not part of the fake-server unit
+suite.

--- a/integrations/cli/meme-search
+++ b/integrations/cli/meme-search
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Executable entrypoint for the Meme Search CLI."""
+
+from meme_search_cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/cli/meme_search_cli.py
+++ b/integrations/cli/meme_search_cli.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Zero-dependency command-line client for the Meme Search API."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import ipaddress
+import json
+import os
+import re
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, BinaryIO, Mapping, Sequence, TextIO
+
+
+DEFAULT_URL = "http://127.0.0.1:3000"
+DEFAULT_TIMEOUT = 15.0
+DEFAULT_LIMIT = 10
+MAX_LIMIT = 20
+USER_AGENT = "meme-search-cli/0.1"
+TOKEN_ENV = "MEME_SEARCH_API_TOKEN"
+URL_ENV = "MEME_SEARCH_URL"
+
+
+class CliError(Exception):
+    """An expected, user-actionable CLI error."""
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Keep bearer credentials from following redirects to another origin."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: BinaryIO,
+        code: int,
+        msg: str,
+        headers: Mapping[str, str],
+        newurl: str,
+    ) -> None:
+        return None
+
+
+def _is_loopback(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    if hostname.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def normalize_base_url(value: str) -> str:
+    """Validate an API origin and return it without a trailing slash."""
+    parsed = urllib.parse.urlsplit(value.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise CliError("instance URL must be an http:// or https:// origin")
+    if parsed.username or parsed.password:
+        raise CliError("instance URL must not contain credentials")
+    if parsed.query or parsed.fragment:
+        raise CliError("instance URL must not contain a query or fragment")
+    if parsed.path not in {"", "/"}:
+        raise CliError("instance URL must be an origin without a path")
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise CliError("instance URL contains an invalid port") from error
+    if parsed.scheme == "http" and not _is_loopback(parsed.hostname):
+        raise CliError(
+            "plain HTTP is only allowed for loopback instances; use HTTPS for remote hosts"
+        )
+
+    hostname = parsed.hostname
+    assert hostname is not None
+    display_host = f"[{hostname}]" if ":" in hostname else hostname
+    authority = display_host if port is None else f"{display_host}:{port}"
+    return f"{parsed.scheme}://{authority}"
+
+
+def _relative_api_url(base_url: str, relative_path: str) -> str:
+    """Resolve a server-provided API path without allowing token exfiltration."""
+    parsed = urllib.parse.urlsplit(relative_path)
+    if parsed.scheme or parsed.netloc or not relative_path.startswith("/"):
+        raise CliError("content URL must be a relative path from this Meme Search instance")
+    if parsed.query or parsed.fragment or not re.fullmatch(
+        r"/api/v1/memes/[1-9][0-9]*/content", parsed.path
+    ):
+        raise CliError("content URL must point to a v1 meme content route")
+    return f"{base_url}{relative_path}"
+
+
+def _message_from_http_error(error: urllib.error.HTTPError) -> str:
+    detail = ""
+    try:
+        body = error.read(32_768)
+        payload = json.loads(body.decode("utf-8"))
+        if isinstance(payload, Mapping):
+            candidate = payload.get("error") or payload.get("message")
+            if isinstance(candidate, str):
+                detail = candidate.strip()
+            elif isinstance(candidate, Mapping):
+                nested = candidate.get("message")
+                if isinstance(nested, str):
+                    detail = nested.strip()
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        pass
+    suffix = f": {detail}" if detail else ""
+    return f"API request failed with HTTP {error.code}{suffix}"
+
+
+def _redact_secret(message: str, secret: str) -> str:
+    if not secret:
+        return message
+    return message.replace(secret, "[REDACTED]")
+
+
+class MemeSearchClient:
+    """Small urllib-based client for the read-only v1 API."""
+
+    def __init__(self, base_url: str, token: str, timeout: float = DEFAULT_TIMEOUT):
+        self.base_url = normalize_base_url(base_url)
+        self.token = token.strip()
+        if not self.token:
+            raise CliError(f"{TOKEN_ENV} is required")
+        if timeout <= 0:
+            raise CliError("timeout must be greater than zero")
+        self.timeout = timeout
+        self.opener = urllib.request.build_opener(_NoRedirectHandler())
+
+    def _request(self, url: str, accept: str) -> urllib.response.addinfourl:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": accept,
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": USER_AGENT,
+            },
+            method="GET",
+        )
+        try:
+            return self.opener.open(request, timeout=self.timeout)
+        except urllib.error.HTTPError as error:
+            message = _redact_secret(_message_from_http_error(error), self.token)
+            raise CliError(message) from error
+        except urllib.error.URLError as error:
+            reason = getattr(error, "reason", error)
+            if isinstance(reason, TimeoutError):
+                raise CliError("Meme Search request timed out") from error
+            message = _redact_secret(
+                f"could not connect to Meme Search: {reason}",
+                self.token,
+            )
+            raise CliError(message) from error
+        except TimeoutError as error:
+            raise CliError("Meme Search request timed out") from error
+
+    def search(
+        self,
+        query: str,
+        *,
+        mode: str = "keyword",
+        tags: Sequence[str] = (),
+        limit: int = DEFAULT_LIMIT,
+    ) -> dict[str, Any]:
+        query = query.strip()
+        if not query:
+            raise CliError("search query must not be empty")
+        if mode not in {"keyword", "vector"}:
+            raise CliError("search mode must be keyword or vector")
+        if not 1 <= limit <= MAX_LIMIT:
+            raise CliError(f"limit must be between 1 and {MAX_LIMIT}")
+
+        parameters: list[tuple[str, str]] = [
+            ("q", query),
+            ("mode", mode),
+            ("limit", str(limit)),
+        ]
+        parameters.extend(("tag", tag.strip()) for tag in tags if tag.strip())
+        url = f"{self.base_url}/api/v1/search?{urllib.parse.urlencode(parameters)}"
+        response = self._request(url, "application/json")
+        try:
+            try:
+                body = response.read()
+            except (http.client.HTTPException, OSError) as error:
+                raise CliError("API response was interrupted before it completed") from error
+        finally:
+            response.close()
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise CliError("API returned invalid JSON") from error
+        _validate_search_payload(payload, self.base_url)
+        return payload
+
+    def fetch(self, meme_or_content_url: str, destination: Path, *, force: bool = False) -> int:
+        relative_path = content_path(meme_or_content_url)
+        url = _relative_api_url(self.base_url, relative_path)
+        destination = destination.expanduser()
+        if destination.is_symlink():
+            raise CliError(f"refusing to write through symlink: {destination}")
+        if destination.exists() and not force:
+            raise CliError(f"output already exists (use --force to replace it): {destination}")
+        if destination.exists() and not destination.is_file():
+            raise CliError(f"output is not a regular file: {destination}")
+        if not destination.parent.is_dir():
+            raise CliError(f"output directory does not exist: {destination.parent}")
+
+        response = self._request(url, "image/*,video/*,application/octet-stream")
+        temp_path: Path | None = None
+        total_bytes = 0
+        try:
+            content_type = response.headers.get_content_type()
+            if not (
+                content_type.startswith("image/")
+                or content_type == "application/octet-stream"
+            ):
+                raise CliError(
+                    f"API returned an unexpected media type: {content_type}"
+                )
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                prefix=f".{destination.name}.",
+                suffix=".download",
+                dir=destination.parent,
+                delete=False,
+            ) as temporary:
+                temp_path = Path(temporary.name)
+                total_bytes = _copy_stream(
+                    response,
+                    temporary,
+                    expected_bytes=_content_length(response)
+                )
+            _commit_download(temp_path, destination, force=force)
+            temp_path = None
+        except (http.client.HTTPException, OSError) as error:
+            raise CliError(f"could not save media to {destination}: {error}") from error
+        finally:
+            response.close()
+            if temp_path is not None:
+                try:
+                    temp_path.unlink()
+                except FileNotFoundError:
+                    pass
+        return total_bytes
+
+
+def _validate_search_payload(payload: Any, base_url: str) -> None:
+    if not isinstance(payload, dict):
+        raise CliError("API returned an unexpected search response")
+
+    data = payload.get("data")
+    meta = payload.get("meta")
+    if not isinstance(data, list) or not isinstance(meta, Mapping):
+        raise CliError("API returned an unexpected search response")
+
+    required_meta = {
+        "query": str,
+        "mode": str,
+        "tags": list,
+        "limit": int,
+        "count": int,
+    }
+    for field, expected_type in required_meta.items():
+        if not isinstance(meta.get(field), expected_type):
+            raise CliError("API returned an unexpected search response")
+    if meta["mode"] not in {"keyword", "vector"}:
+        raise CliError("API returned an unexpected search response")
+    if not all(isinstance(tag, str) for tag in meta["tags"]):
+        raise CliError("API returned an unexpected search response")
+    if (
+        isinstance(meta["limit"], bool)
+        or not 1 <= meta["limit"] <= MAX_LIMIT
+        or isinstance(meta["count"], bool)
+        or not 0 <= meta["count"] <= MAX_LIMIT
+    ):
+        raise CliError("API returned an unexpected search response")
+
+    for item in data:
+        if not isinstance(item, Mapping):
+            raise CliError("API returned an unexpected search response")
+        meme_id = item.get("id")
+        if isinstance(meme_id, bool) or not isinstance(meme_id, int) or meme_id < 1:
+            raise CliError("API returned an unexpected search response")
+        if not isinstance(item.get("filename"), str):
+            raise CliError("API returned an unexpected search response")
+        if item.get("description") is not None and not isinstance(
+            item.get("description"), str
+        ):
+            raise CliError("API returned an unexpected search response")
+        tags = item.get("tags")
+        if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+            raise CliError("API returned an unexpected search response")
+        if not isinstance(item.get("media_type"), str):
+            raise CliError("API returned an unexpected search response")
+        content_url = item.get("content_url")
+        if not isinstance(content_url, str):
+            raise CliError("API returned an unexpected search response")
+        _relative_api_url(base_url, content_url)
+
+
+def _content_length(response: urllib.response.addinfourl) -> int | None:
+    raw_value = response.headers.get("Content-Length")
+    if raw_value is None:
+        return None
+    try:
+        value = int(raw_value)
+    except ValueError as error:
+        raise CliError("API returned an invalid Content-Length") from error
+    if value < 0:
+        raise CliError("API returned an invalid Content-Length")
+    return value
+
+
+def _copy_stream(
+    source: BinaryIO,
+    destination: BinaryIO,
+    *,
+    expected_bytes: int | None = None,
+) -> int:
+    total = 0
+    while True:
+        chunk = source.read(64 * 1024)
+        if not chunk:
+            break
+        destination.write(chunk)
+        total += len(chunk)
+    if expected_bytes is not None and total != expected_bytes:
+        raise CliError(
+            f"media download was incomplete (expected {expected_bytes} bytes, received {total})"
+        )
+    return total
+
+
+def _commit_download(temp_path: Path, destination: Path, *, force: bool) -> None:
+    if force:
+        os.replace(temp_path, destination)
+        return
+
+    try:
+        os.link(temp_path, destination)
+    except FileExistsError as error:
+        raise CliError(f"output already exists (use --force to replace it): {destination}") from error
+    temp_path.unlink()
+
+
+def content_path(value: str) -> str:
+    """Accept either a numeric meme ID or a relative content_url from search."""
+    value = value.strip()
+    if re.fullmatch(r"[1-9][0-9]*", value):
+        return f"/api/v1/memes/{value}/content"
+    if value.startswith("/"):
+        return value
+    raise CliError("fetch target must be a numeric meme ID or a relative content_url")
+
+
+def _safe_text(value: Any) -> str:
+    text = "" if value is None else str(value)
+    return "".join(character if character.isprintable() else " " for character in text)
+
+
+def print_human_results(payload: Mapping[str, Any], output: TextIO) -> None:
+    results = payload.get("data", [])
+    assert isinstance(results, list)
+    if not results:
+        print("No memes found.", file=output)
+        return
+
+    for index, item in enumerate(results, start=1):
+        if not isinstance(item, Mapping):
+            continue
+        meme_id = _safe_text(item.get("id", "?"))
+        filename = _safe_text(item.get("filename", "(unnamed)"))
+        print(f"{index}. [{meme_id}] {filename}", file=output)
+        description = _safe_text(item.get("description"))
+        if description:
+            print(f"   {description}", file=output)
+        tags = item.get("tags")
+        if isinstance(tags, list) and tags:
+            print(f"   tags: {', '.join(_safe_text(tag) for tag in tags)}", file=output)
+        content_url = _safe_text(item.get("content_url"))
+        if content_url:
+            print(f"   content: {content_url}", file=output)
+
+    meta = payload.get("meta")
+    if isinstance(meta, Mapping):
+        shown = len(results)
+        count = meta.get("count")
+        if isinstance(count, int) and count != shown:
+            print(f"\nShowing {shown} of {count} result(s).", file=output)
+
+
+def build_parser(environ: Mapping[str, str] | None = None) -> argparse.ArgumentParser:
+    environment = os.environ if environ is None else environ
+    parser = argparse.ArgumentParser(
+        prog="meme-search",
+        description="Search and download memes from a local Meme Search instance.",
+    )
+    parser.add_argument(
+        "--url",
+        default=environment.get(URL_ENV, DEFAULT_URL),
+        help=f"instance origin (default: ${URL_ENV} or {DEFAULT_URL})",
+    )
+    parser.add_argument(
+        "--timeout",
+        default=DEFAULT_TIMEOUT,
+        type=float,
+        help=f"request timeout in seconds (default: {DEFAULT_TIMEOUT:g})",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    search_parser = subparsers.add_parser("search", help="search the meme collection")
+    search_parser.add_argument("query", help="words or meaning to search for")
+    search_parser.add_argument(
+        "--mode",
+        choices=("keyword", "vector"),
+        default="keyword",
+        help="search method (default: keyword)",
+    )
+    search_parser.add_argument(
+        "--tag",
+        action="append",
+        default=[],
+        help="require a tag; repeat to supply multiple tags",
+    )
+    search_parser.add_argument(
+        "--limit",
+        default=DEFAULT_LIMIT,
+        type=int,
+        help=f"maximum results, 1-{MAX_LIMIT} (default: {DEFAULT_LIMIT})",
+    )
+    search_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print the API response as formatted JSON",
+    )
+
+    fetch_parser = subparsers.add_parser("fetch", help="download a meme's media")
+    fetch_parser.add_argument(
+        "target",
+        help="numeric meme ID or relative content_url returned by search",
+    )
+    fetch_parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        required=True,
+        help="destination file (parent directory must exist)",
+    )
+    fetch_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="replace an existing regular file",
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    environment = os.environ if environ is None else environ
+    parser = build_parser(environment)
+    args = parser.parse_args(argv)
+    token = environment.get(TOKEN_ENV, "")
+    try:
+        client = MemeSearchClient(args.url, token, args.timeout)
+        if args.command == "search":
+            payload = client.search(
+                args.query,
+                mode=args.mode,
+                tags=args.tag,
+                limit=args.limit,
+            )
+            if args.json:
+                json.dump(payload, stdout, indent=2, sort_keys=True)
+                stdout.write("\n")
+            else:
+                print_human_results(payload, stdout)
+        elif args.command == "fetch":
+            byte_count = client.fetch(args.target, args.output, force=args.force)
+            print(f"Saved {byte_count} bytes to {args.output.expanduser()}", file=stdout)
+        return 0
+    except CliError as error:
+        print(f"meme-search: {error}", file=stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/cli/tests/__init__.py
+++ b/integrations/cli/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Meme Search CLI."""

--- a/integrations/cli/tests/test_meme_search_cli.py
+++ b/integrations/cli/tests/test_meme_search_cli.py
@@ -1,0 +1,570 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import threading
+import unittest
+import urllib.error
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+import meme_search_cli
+from meme_search_cli import (
+    _validate_search_payload,
+    CliError,
+    MemeSearchClient,
+    content_path,
+    main,
+    normalize_base_url,
+    print_human_results,
+)
+
+CONFORMANCE_FIXTURES = (
+    Path(__file__).resolve().parents[2]
+    / "shared"
+    / "search-response-conformance.json"
+)
+
+
+class FakeApiHandler(BaseHTTPRequestHandler):
+    requests: list[dict[str, object]] = []
+
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlsplit(self.path)
+        self.__class__.requests.append(
+            {
+                "path": parsed.path,
+                "query": urllib.parse.parse_qs(parsed.query),
+                "authorization": self.headers.get("Authorization"),
+                "accept": self.headers.get("Accept"),
+            }
+        )
+        if self.headers.get("Authorization") != "Bearer test-secret":
+            supplied_token = self.headers.get("Authorization", "").removeprefix(
+                "Bearer "
+            )
+            message = (
+                f"invalid token {supplied_token}"
+                if supplied_token == "reflect-secret"
+                else "invalid token"
+            )
+            status = 403 if supplied_token == "media-only" else 401
+            self._json_response(status, {"error": {"message": message}})
+            return
+        if parsed.path == "/api/v1/search":
+            query = urllib.parse.parse_qs(parsed.query).get("q", [""])[0]
+            if query == "truncated":
+                body = json.dumps({"data": [], "meta": {}}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body) + 20))
+                self.end_headers()
+                self.wfile.write(body)
+                self.wfile.flush()
+                self.close_connection = True
+                return
+            if query == "malformed":
+                body = b"{not-json"
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if query == "unexpected":
+                self._json_response(200, {"data": {}, "meta": []})
+                return
+            if query == "cross-origin":
+                self._json_response(
+                    200,
+                    {
+                        "data": [
+                            {
+                                "id": 42,
+                                "filename": "ship-it.gif",
+                                "description": None,
+                                "tags": [],
+                                "media_type": "image/gif",
+                                "content_url": "https://attacker.example/steal",
+                            }
+                        ],
+                        "meta": {
+                            "query": query,
+                            "mode": "keyword",
+                            "tags": [],
+                            "count": 1,
+                            "limit": 10,
+                        },
+                    },
+                )
+                return
+            self._json_response(
+                200,
+                {
+                    "data": [
+                        {
+                            "id": 42,
+                            "filename": "ship-it.gif",
+                            "description": "A celebratory launch",
+                            "tags": ["deploy", "success"],
+                            "media_type": "image/gif",
+                            "content_url": "/api/v1/memes/42/content",
+                        }
+                    ],
+                    "meta": {
+                        "query": query,
+                        "mode": urllib.parse.parse_qs(parsed.query).get(
+                            "mode", ["keyword"]
+                        )[0],
+                        "tags": urllib.parse.parse_qs(parsed.query).get("tag", []),
+                        "count": 1,
+                        "limit": int(
+                            urllib.parse.parse_qs(parsed.query).get("limit", ["10"])[0]
+                        ),
+                    },
+                },
+            )
+            return
+        if parsed.path == "/api/v1/memes/42/content":
+            body = b"GIF89a-test"
+            self.send_response(200)
+            self.send_header("Content-Type", "image/gif")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if parsed.path == "/api/v1/memes/99/content":
+            self.send_response(302)
+            self.send_header("Location", "/api/v1/captured")
+            self.end_headers()
+            return
+        if parsed.path == "/api/v1/memes/98/content":
+            body = b"<html>not media</html>"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if parsed.path == "/api/v1/memes/97/content":
+            body = b"GIF89a-truncated"
+            self.send_response(200)
+            self.send_header("Content-Type", "image/gif")
+            self.send_header("Content-Length", str(len(body) + 50))
+            self.end_headers()
+            self.wfile.write(body)
+            self.wfile.flush()
+            self.close_connection = True
+            return
+        self._json_response(404, {"error": "not found"})
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        pass
+
+    def _json_response(self, status: int, payload: object) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class CliTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), FakeApiHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        host, port = cls.server.server_address
+        cls.base_url = f"http://{host}:{port}"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=2)
+
+    def setUp(self) -> None:
+        FakeApiHandler.requests.clear()
+
+    def test_shared_search_response_conformance_fixtures(self) -> None:
+        fixtures = json.loads(CONFORMANCE_FIXTURES.read_text(encoding="utf-8"))
+
+        for fixture in fixtures["valid"]:
+            with self.subTest(fixture=fixture["name"]):
+                _validate_search_payload(fixture["payload"], self.base_url)
+
+        for fixture in fixtures["invalid"]:
+            with self.subTest(fixture=fixture["name"]):
+                with self.assertRaisesRegex(
+                    CliError, "unexpected search response|relative path"
+                ):
+                    _validate_search_payload(fixture["payload"], self.base_url)
+
+    def test_search_sends_bearer_token_and_repeated_tags(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+
+        payload = client.search(
+            "ship it",
+            mode="vector",
+            tags=["deploy", "success"],
+            limit=5,
+        )
+
+        self.assertEqual(42, payload["data"][0]["id"])
+        request = FakeApiHandler.requests[0]
+        self.assertEqual("/api/v1/search", request["path"])
+        self.assertEqual(["ship it"], request["query"]["q"])
+        self.assertEqual(["vector"], request["query"]["mode"])
+        self.assertEqual(["deploy", "success"], request["query"]["tag"])
+        self.assertEqual(["5"], request["query"]["limit"])
+        self.assertEqual("Bearer test-secret", request["authorization"])
+        self.assertEqual("application/json", request["accept"])
+
+    def test_json_output_is_script_friendly(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        result = main(
+            ["--url", self.base_url, "search", "ship it", "--json"],
+            environ={"MEME_SEARCH_API_TOKEN": "test-secret"},
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(0, result)
+        self.assertEqual(42, json.loads(stdout.getvalue())["data"][0]["id"])
+        self.assertEqual("", stderr.getvalue())
+
+    def test_human_output_includes_fetchable_content_url(self) -> None:
+        stdout = io.StringIO()
+
+        result = main(
+            ["--url", self.base_url, "search", "ship it"],
+            environ={"MEME_SEARCH_API_TOKEN": "test-secret"},
+            stdout=stdout,
+            stderr=io.StringIO(),
+        )
+
+        self.assertEqual(0, result)
+        self.assertIn("[42] ship-it.gif", stdout.getvalue())
+        self.assertIn("/api/v1/memes/42/content", stdout.getvalue())
+
+    def test_fetch_streams_to_destination_and_refuses_overwrite(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "ship-it.gif"
+
+            byte_count = client.fetch("42", destination)
+
+            self.assertEqual(len(b"GIF89a-test"), byte_count)
+            self.assertEqual(b"GIF89a-test", destination.read_bytes())
+            with self.assertRaisesRegex(CliError, "already exists"):
+                client.fetch("/api/v1/memes/42/content", destination)
+
+    def test_fetch_force_replaces_regular_file(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "ship-it.gif"
+            destination.write_bytes(b"old")
+
+            client.fetch("42", destination, force=True)
+
+            self.assertEqual(b"GIF89a-test", destination.read_bytes())
+
+    def test_truncated_search_and_media_responses_fail_without_artifacts(self) -> None:
+        stderr = io.StringIO()
+        result = main(
+            ["--url", self.base_url, "search", "truncated"],
+            environ={"MEME_SEARCH_API_TOKEN": "test-secret"},
+            stdout=io.StringIO(),
+            stderr=stderr,
+        )
+
+        self.assertEqual(1, result)
+        self.assertIn("interrupted", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+        self.assertNotIn("test-secret", stderr.getvalue())
+
+        client = MemeSearchClient(self.base_url, "test-secret")
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "truncated.gif"
+
+            with self.assertRaisesRegex(CliError, "incomplete"):
+                client.fetch("97", destination)
+
+            self.assertFalse(destination.exists())
+            self.assertEqual([], list(Path(directory).glob(".*.download")))
+
+    def test_no_force_commit_does_not_clobber_a_concurrent_destination(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+        copy_finished = threading.Event()
+        allow_commit = threading.Event()
+        failures: list[Exception] = []
+        original_copy = meme_search_cli._copy_stream
+
+        def blocking_copy(*args: object, **kwargs: object) -> int:
+            byte_count = original_copy(*args, **kwargs)
+            copy_finished.set()
+            if not allow_commit.wait(timeout=2):
+                raise RuntimeError("test barrier timed out")
+            return byte_count
+
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "raced.gif"
+
+            def download() -> None:
+                try:
+                    client.fetch("42", destination)
+                except Exception as error:  # capture the worker-thread result
+                    failures.append(error)
+
+            with mock.patch(
+                "meme_search_cli._copy_stream",
+                side_effect=blocking_copy,
+            ):
+                thread = threading.Thread(target=download)
+                thread.start()
+                self.assertTrue(copy_finished.wait(timeout=2))
+                destination.write_bytes(b"concurrent winner")
+                allow_commit.set()
+                thread.join(timeout=2)
+
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(b"concurrent winner", destination.read_bytes())
+            self.assertEqual(1, len(failures))
+            self.assertIsInstance(failures[0], CliError)
+            self.assertIn("already exists", str(failures[0]))
+            self.assertEqual([], list(Path(directory).glob(".*.download")))
+
+    def test_force_replacement_is_atomic_and_explicit(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+        replacement_ready = threading.Event()
+        allow_replacement = threading.Event()
+        failures: list[Exception] = []
+        original_replace = meme_search_cli.os.replace
+
+        def blocking_replace(source: Path, destination: Path) -> None:
+            replacement_ready.set()
+            if not allow_replacement.wait(timeout=2):
+                raise RuntimeError("test barrier timed out")
+            original_replace(source, destination)
+
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "forced.gif"
+            destination.write_bytes(b"old complete file")
+
+            def download() -> None:
+                try:
+                    client.fetch("42", destination, force=True)
+                except Exception as error:  # capture the worker-thread result
+                    failures.append(error)
+
+            with mock.patch("meme_search_cli.os.replace", side_effect=blocking_replace):
+                thread = threading.Thread(target=download)
+                thread.start()
+                self.assertTrue(replacement_ready.wait(timeout=2))
+                self.assertEqual(b"old complete file", destination.read_bytes())
+                allow_replacement.set()
+                thread.join(timeout=2)
+
+            self.assertFalse(thread.is_alive())
+            self.assertEqual([], failures)
+            self.assertEqual(b"GIF89a-test", destination.read_bytes())
+            self.assertEqual([], list(Path(directory).glob(".*.download")))
+
+    def test_fetch_refuses_symlink_even_with_force(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "target.gif"
+            target.write_bytes(b"do not replace")
+            symlink = Path(directory) / "output.gif"
+            try:
+                symlink.symlink_to(target)
+            except (NotImplementedError, OSError):
+                self.skipTest("symlinks are not supported")
+
+            with self.assertRaisesRegex(CliError, "symlink"):
+                client.fetch("42", symlink, force=True)
+
+            self.assertEqual(b"do not replace", target.read_bytes())
+
+    def test_fetch_does_not_follow_redirects_with_bearer_token(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(CliError, "HTTP 302"):
+                client.fetch("99", Path(directory) / "redirected.gif")
+
+        self.assertEqual(
+            ["/api/v1/memes/99/content"],
+            [request["path"] for request in FakeApiHandler.requests],
+        )
+
+    def test_server_error_is_concise_and_does_not_leak_token(self) -> None:
+        client = MemeSearchClient(self.base_url, "wrong-secret")
+
+        with self.assertRaises(CliError) as raised:
+            client.search("ship it")
+
+        self.assertIn("HTTP 401: invalid token", str(raised.exception))
+        self.assertNotIn("wrong-secret", str(raised.exception))
+
+    def test_server_error_redacts_a_reflected_token(self) -> None:
+        client = MemeSearchClient(self.base_url, "reflect-secret")
+
+        with self.assertRaises(CliError) as raised:
+            client.search("ship it")
+
+        self.assertIn("[REDACTED]", str(raised.exception))
+        self.assertNotIn("reflect-secret", str(raised.exception))
+
+    def test_scope_error_is_concise_and_nonzero(self) -> None:
+        stderr = io.StringIO()
+
+        result = main(
+            ["--url", self.base_url, "search", "ship it"],
+            environ={"MEME_SEARCH_API_TOKEN": "media-only"},
+            stdout=io.StringIO(),
+            stderr=stderr,
+        )
+
+        self.assertEqual(1, result)
+        self.assertIn("HTTP 403", stderr.getvalue())
+        self.assertNotIn("media-only", stderr.getvalue())
+
+    def test_malformed_and_unexpected_search_responses_fail_safely(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+
+        with self.assertRaisesRegex(CliError, "invalid JSON"):
+            client.search("malformed")
+        with self.assertRaisesRegex(CliError, "unexpected search response"):
+            client.search("unexpected")
+        with self.assertRaisesRegex(CliError, "relative path"):
+            client.search("cross-origin")
+
+    def test_human_output_strips_terminal_control_characters(self) -> None:
+        output = io.StringIO()
+
+        print_human_results(
+            {
+                "data": [
+                    {
+                        "id": 42,
+                        "filename": "safe\x1b[31m.gif\nnext-line",
+                        "description": "description\rrewritten",
+                        "tags": ["tag\tname"],
+                        "content_url": "/api/v1/memes/42/content",
+                    }
+                ]
+            },
+            output,
+        )
+
+        rendered = output.getvalue()
+        self.assertNotIn("\x1b", rendered)
+        self.assertNotIn("\r", rendered)
+        self.assertIn("safe [31m.gif next-line", rendered)
+        self.assertIn("next-line", rendered.splitlines()[0])
+
+    def test_timeout_and_network_errors_are_actionable_and_secret_safe(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+
+        client.opener = mock.Mock()
+        client.opener.open.side_effect = TimeoutError()
+        with self.assertRaisesRegex(CliError, "timed out"):
+            client.search("ship it")
+
+        client.opener.open.side_effect = urllib.error.URLError(
+            "connection refused for test-secret"
+        )
+        with self.assertRaises(CliError) as raised:
+            client.search("ship it")
+        self.assertIn("could not connect", str(raised.exception))
+        self.assertIn("[REDACTED]", str(raised.exception))
+        self.assertNotIn("test-secret", str(raised.exception))
+
+    def test_token_is_required(self) -> None:
+        stderr = io.StringIO()
+
+        result = main(
+            ["--url", self.base_url, "search", "ship it"],
+            environ={},
+            stdout=io.StringIO(),
+            stderr=stderr,
+        )
+
+        self.assertEqual(1, result)
+        self.assertIn("MEME_SEARCH_API_TOKEN is required", stderr.getvalue())
+
+    def test_instance_url_can_come_from_supplied_environment(self) -> None:
+        stdout = io.StringIO()
+
+        result = main(
+            ["search", "ship it", "--json"],
+            environ={
+                "MEME_SEARCH_API_TOKEN": "test-secret",
+                "MEME_SEARCH_URL": self.base_url,
+            },
+            stdout=stdout,
+            stderr=io.StringIO(),
+        )
+
+        self.assertEqual(0, result)
+        self.assertEqual(42, json.loads(stdout.getvalue())["data"][0]["id"])
+
+    def test_plain_http_remote_url_is_rejected(self) -> None:
+        with self.assertRaisesRegex(CliError, "plain HTTP"):
+            normalize_base_url("http://example.com:3000")
+
+        self.assertEqual("https://example.com", normalize_base_url("https://example.com/"))
+
+    def test_url_with_credentials_or_path_is_rejected(self) -> None:
+        with self.assertRaisesRegex(CliError, "credentials"):
+            normalize_base_url("https://user:secret@example.com")
+        with self.assertRaisesRegex(CliError, "without a path"):
+            normalize_base_url("https://example.com/meme-search")
+
+    def test_content_path_rejects_absolute_or_ambiguous_targets(self) -> None:
+        self.assertEqual("/api/v1/memes/12/content", content_path("12"))
+        self.assertEqual(
+            "/api/v1/memes/12/content",
+            content_path("/api/v1/memes/12/content"),
+        )
+        with self.assertRaises(CliError):
+            content_path("https://attacker.example/content")
+        with self.assertRaises(CliError):
+            content_path("zero")
+        with self.assertRaisesRegex(CliError, "meme content route"):
+            client = MemeSearchClient(self.base_url, "test-secret")
+            client.fetch(
+                "/api/v1/memes/12/content?redirect=https://attacker.example",
+                Path("not-created"),
+            )
+
+    def test_fetch_rejects_non_content_api_path(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(CliError, "meme content route"):
+                client.fetch(
+                    "/api/v1/search",
+                    Path(directory) / "not-media",
+                )
+
+    def test_fetch_rejects_non_media_response_and_missing_directory(self) -> None:
+        client = MemeSearchClient(self.base_url, "test-secret")
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(CliError, "unexpected media type"):
+                client.fetch("98", Path(directory) / "not-media")
+            self.assertFalse((Path(directory) / "not-media").exists())
+
+            missing_parent = Path(directory) / "missing" / "output.gif"
+            with self.assertRaisesRegex(CliError, "directory does not exist"):
+                client.fetch("42", missing_parent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/meme_search/meme_search_app/app/services/search_relevance_evaluator.rb
+++ b/meme_search/meme_search_app/app/services/search_relevance_evaluator.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "yaml"
+require "pathname"
+
+class SearchRelevanceEvaluator
+  Result = Data.define(:case_results, :metrics)
+  DatasetError = Class.new(ArgumentError)
+  MODES = %w[keyword vector].freeze
+
+  def self.load_cases(path)
+    document = YAML.safe_load_file(path)
+    raise DatasetError, "dataset root must be a mapping" unless document.is_a?(Hash)
+    unless document["version"] == 2
+      raise DatasetError,
+        "dataset version must be 2; filename-only v1 fixtures are ambiguous and must be migrated"
+    end
+    if document["template_only"] == true
+      raise DatasetError,
+        "dataset is a replace-me template; copy it, set template_only to false, and add private expected IDs or paths"
+    end
+
+    validate_cases!(document["cases"])
+    document["cases"]
+  rescue Errno::ENOENT
+    raise DatasetError, "dataset file was not found: #{path}"
+  rescue Psych::SyntaxError => e
+    raise DatasetError, "dataset YAML is invalid at line #{e.line}: #{e.problem}"
+  end
+
+  def self.validate_cases!(cases)
+    raise DatasetError, "cases must be an array" unless cases.is_a?(Array)
+
+    cases.map.with_index do |test_case, index|
+      label = "case #{index + 1}"
+      raise DatasetError, "#{label} must be a mapping" unless test_case.is_a?(Hash)
+
+      query = test_case["query"]
+      unless query.is_a?(String) && query.present? && query.length <= 200
+        raise DatasetError, "#{label} query must be a non-empty string of at most 200 characters"
+      end
+
+      mode = test_case.fetch("mode", "keyword")
+      raise DatasetError, "#{label} mode must be keyword or vector" unless MODES.include?(mode)
+
+      expected = test_case["expected"]
+      unless expected.is_a?(Array) && expected.any? &&
+          expected.all? { |identifier| identifier.is_a?(Hash) }
+        raise DatasetError, "#{label} expected must contain one or more {id: ...} or {path: ...} mappings"
+      end
+      normalized_expected = expected.map { |identifier| normalize_expected_identifier(identifier, label) }
+
+      tags = test_case.fetch("tags", [])
+      unless tags.is_a?(Array) && tags.length <= 10 &&
+          tags.all? { |tag| tag.is_a?(String) && tag.present? && tag.length <= 20 }
+        raise DatasetError, "#{label} tags must contain at most 10 non-empty names of at most 20 characters"
+      end
+      test_case.merge("expected" => normalized_expected)
+    end
+  end
+
+  def self.normalize_expected_identifier(identifier, label)
+    unless identifier.keys.length == 1
+      raise DatasetError, "#{label} expected identifiers must contain exactly one id or path"
+    end
+
+    if identifier.key?("id")
+      id = identifier["id"]
+      unless id.is_a?(Integer) && id.positive?
+        raise DatasetError, "#{label} expected id must be a positive integer"
+      end
+      return "id:#{id}"
+    end
+
+    unless identifier.key?("path")
+      raise DatasetError, "#{label} expected identifiers must contain id or path"
+    end
+
+    "path:#{normalize_relative_path(identifier['path'], label:)}"
+  end
+
+  def self.normalize_relative_path(value, label: "result")
+    unless value.is_a?(String) && value.present?
+      raise DatasetError, "#{label} expected path must be a non-empty relative path"
+    end
+
+    portable_value = value.tr("\\", "/")
+    path = Pathname.new(portable_value)
+    normalized = path.cleanpath.to_s.tr("\\", "/")
+    segments = Pathname.new(normalized).each_filename.to_a
+    if path.absolute? || segments.length < 2 || segments.any? { |segment| segment == ".." }
+      raise DatasetError, "#{label} expected path must include a library directory and filename"
+    end
+
+    normalized
+  end
+
+  def initialize(cases:, searcher:)
+    @cases = self.class.validate_cases!(cases)
+    @searcher = searcher
+  end
+
+  def call(k: ImageSearchQuery::DEFAULT_RESULT_LIMIT)
+    unless k.is_a?(Integer) && k.between?(1, ImageSearchQuery::MAX_RESULT_LIMIT)
+      raise ArgumentError, "k must be an integer between 1 and #{ImageSearchQuery::MAX_RESULT_LIMIT}"
+    end
+
+    case_results = cases.map { |test_case| evaluate_case(test_case, k:) }
+    Result.new(
+      case_results: case_results,
+      metrics: aggregate(case_results, k:)
+    )
+  end
+
+  private
+
+    attr_reader :cases, :searcher
+
+    def evaluate_case(test_case, k:)
+      expected = Array(test_case.fetch("expected")).map(&:to_s).uniq
+      ranked_results = Array(searcher.call(test_case, k)).first(k).map { |result| result_identifiers(result) }
+      returned = ranked_results.map { |result| result.fetch(:display) }
+      relevant_ranks = ranked_results.each_index
+        .select { |index| (expected & ranked_results[index].fetch(:identifiers)).any? }
+        .map { |index| index + 1 }
+      matched_expected = expected.select do |identifier|
+        ranked_results.any? { |result| result.fetch(:identifiers).include?(identifier) }
+      end
+
+      {
+        "query" => test_case.fetch("query"),
+        "k" => k,
+        "expected" => expected,
+        "returned" => returned,
+        "hit" => relevant_ranks.any?,
+        "reciprocal_rank" => relevant_ranks.any? ? 1.0 / relevant_ranks.first : 0.0,
+        "recall" => expected.empty? ? 0.0 : matched_expected.length.fdiv(expected.length)
+      }
+    end
+
+    def result_identifiers(result)
+      identifiers = []
+      id = result.id if result.respond_to?(:id)
+      identifiers << "id:#{id}" if id.is_a?(Integer) && id.positive?
+
+      path = result_relative_path(result)
+      identifiers << "path:#{path}" if path
+
+      if identifiers.empty?
+        raise DatasetError, "search result is missing both a positive id and a normalized relative path"
+      end
+
+      {
+        identifiers: identifiers,
+        display: identifiers.find { |identifier| identifier.start_with?("path:") } || identifiers.first
+      }
+    end
+
+    def result_relative_path(result)
+      raw_path = if result.respond_to?(:relative_path)
+        result.relative_path
+      elsif result.respond_to?(:image_path) && result.respond_to?(:name) && result.image_path
+        File.join(result.image_path.name.to_s, result.name.to_s)
+      end
+      return if raw_path.blank?
+
+      self.class.normalize_relative_path(raw_path)
+    rescue DatasetError
+      nil
+    end
+
+    def aggregate(case_results, k:)
+      count = case_results.length
+      if count.zero?
+        return {
+          "k" => k,
+          "case_count" => 0,
+          "hit_rate" => 0.0,
+          "mrr" => 0.0,
+          "mean_recall" => 0.0
+        }
+      end
+
+      {
+        "k" => k,
+        "case_count" => count,
+        "hit_rate" => case_results.count { |result| result["hit"] }.fdiv(count),
+        "mrr" => case_results.sum { |result| result["reciprocal_rank"] }.fdiv(count),
+        "mean_recall" => case_results.sum { |result| result["recall"] }.fdiv(count)
+      }
+    end
+end

--- a/meme_search/meme_search_app/benchmark/search_relevance.yml
+++ b/meme_search/meme_search_app/benchmark/search_relevance.yml
@@ -1,0 +1,25 @@
+version: 2
+template_only: true
+
+# REPLACE-ME TEMPLATE ONLY — this is not a canonical dataset, a quality claim,
+# or a CI/release gate. Copy this file outside the repository, set
+# template_only: false, and replace every example with private stable IDs or
+# normalized paths relative to public/memes. Bare filenames are rejected
+# because two registered directories can contain the same name. Never commit
+# private identifiers, images, descriptions, or embeddings.
+#
+# The evaluator compares expected stable IDs or normalized library-relative
+# paths with ranked search results and never needs controllers, Turbo,
+# templates, or browser state.
+cases:
+  - query: "production incident"
+    mode: keyword
+    expected:
+      - path: "example-folder/example-incident-reaction.gif"
+
+  - query: "surprised reaction"
+    mode: vector
+    tags:
+      - "reaction"
+    expected:
+      - id: 123

--- a/meme_search/meme_search_app/lib/tasks/search_relevance.rake
+++ b/meme_search/meme_search_app/lib/tasks/search_relevance.rake
@@ -1,0 +1,29 @@
+require "json"
+namespace :search do
+  desc "Evaluate search relevance from a v2 YAML dataset with expected IDs or paths (DATASET=... K=10)"
+  task relevance: :environment do
+    dataset_path = ENV.fetch("DATASET", Rails.root.join("benchmark", "search_relevance.yml")).to_s
+    k = Integer(ENV.fetch("K", ImageSearchQuery::DEFAULT_RESULT_LIMIT).to_s, 10)
+    cases = SearchRelevanceEvaluator.load_cases(dataset_path)
+
+    evaluator = SearchRelevanceEvaluator.new(
+      cases: cases,
+      searcher: lambda do |test_case, limit|
+        ImageSearchQuery.new(
+          query: test_case.fetch("query"),
+          mode: test_case.fetch("mode", "keyword"),
+          selected_tag_names: test_case.fetch("tags", []),
+          limit: limit
+        ).call
+      end
+    )
+
+    result = evaluator.call(k: k)
+    puts JSON.pretty_generate(
+      metrics: result.metrics,
+      cases: result.case_results
+    )
+  rescue ArgumentError, SearchRelevanceEvaluator::DatasetError => e
+    abort "Search relevance evaluation failed: #{e.message}"
+  end
+end

--- a/meme_search/meme_search_app/test/services/search_relevance_evaluator_test.rb
+++ b/meme_search/meme_search_app/test/services/search_relevance_evaluator_test.rb
@@ -1,0 +1,167 @@
+require "test_helper"
+require "tempfile"
+
+class SearchRelevanceEvaluatorTest < ActiveSupport::TestCase
+  TestResult = Data.define(:id, :relative_path)
+
+  test "computes hit rate reciprocal rank and recall independent of the UI" do
+    cases = [
+      { "query" => "incident", "expected" => [ { "path" => "work/incident.gif" } ] },
+      {
+        "query" => "surprise",
+        "expected" => [ { "id" => 7 }, { "path" => "reactions/shock.jpg" } ]
+      },
+      { "query" => "missing", "expected" => [ { "id" => 99 } ] }
+    ]
+    results = {
+      "incident" => [
+        TestResult.new(id: 1, relative_path: "other/incident.gif"),
+        TestResult.new(id: 2, relative_path: "work/incident.gif")
+      ],
+      "surprise" => [
+        TestResult.new(id: 7, relative_path: "reactions/surprise.jpg"),
+        TestResult.new(id: 8, relative_path: "other/unrelated.jpg")
+      ],
+      "missing" => [ TestResult.new(id: 3, relative_path: "other/missing.jpg") ]
+    }
+    searcher = ->(test_case, _limit) { results.fetch(test_case.fetch("query")) }
+
+    result = SearchRelevanceEvaluator.new(cases:, searcher:).call(k: 2)
+
+    assert_equal 3, result.metrics["case_count"]
+    assert_equal 2, result.metrics["k"]
+    assert_in_delta 2.0 / 3, result.metrics["hit_rate"]
+    assert_in_delta 0.5, result.metrics["mrr"]
+    assert_in_delta 0.5, result.metrics["mean_recall"]
+    assert_equal(
+      %w[path:other/incident.gif path:work/incident.gif],
+      result.case_results.first["returned"]
+    )
+    assert_equal 0.5, result.case_results.first["reciprocal_rank"]
+    assert_equal 0.5, result.case_results.second["recall"]
+    assert_equal false, result.case_results.last["hit"]
+  end
+
+  test "returns zeroed metrics for an empty dataset" do
+    result = SearchRelevanceEvaluator.new(cases: [], searcher: ->(*) { flunk }).call
+
+    assert_equal(
+      { "k" => 10, "case_count" => 0, "hit_rate" => 0.0, "mrr" => 0.0, "mean_recall" => 0.0 },
+      result.metrics
+    )
+  end
+
+  test "rejects k values outside the API result bounds" do
+    evaluator = SearchRelevanceEvaluator.new(cases: [], searcher: ->(*) { [] })
+
+    [ 0, 21, "10" ].each do |invalid_k|
+      assert_raises(ArgumentError) { evaluator.call(k: invalid_k) }
+    end
+  end
+
+  test "validates dataset shape with actionable case locations" do
+    invalid_cases = [
+      nil,
+      [ "not a mapping" ],
+      [ { "query" => "", "expected" => [ { "id" => 1 } ] } ],
+      [ { "query" => "reaction", "mode" => "sql", "expected" => [ { "id" => 1 } ] } ],
+      [ { "query" => "reaction", "expected" => [] } ],
+      [ { "query" => "reaction", "expected" => [ { "id" => 1 } ], "tags" => [ "x" * 21 ] } ],
+      [ { "query" => "reaction", "expected" => [ { "id" => nil } ] } ],
+      [ { "query" => "reaction", "expected" => [ { "id" => 1, "path" => "work/meme.gif" } ] } ],
+      [ { "query" => "reaction", "expected" => [ { "path" => "meme.gif" } ] } ],
+      [ { "query" => "reaction", "expected" => [ "meme.gif" ] } ]
+    ]
+
+    invalid_cases.each do |cases|
+      assert_raises(SearchRelevanceEvaluator::DatasetError) do
+        SearchRelevanceEvaluator.new(cases:, searcher: ->(*) { [] })
+      end
+    end
+  end
+
+  test "loads a private dataset and rejects the checked-in template marker" do
+    valid_file = Tempfile.new([ "search-relevance-valid", ".yml" ])
+    valid_file.write(<<~YAML)
+      version: 1
+      template_only: false
+      cases:
+        - query: "reaction"
+          expected: ["private-reaction.gif"]
+    YAML
+    valid_file.flush
+
+    assert_raises(SearchRelevanceEvaluator::DatasetError) do
+      SearchRelevanceEvaluator.load_cases(valid_file.path)
+    end
+
+    valid_file.rewind
+    valid_file.truncate(0)
+    valid_file.write(<<~YAML)
+      version: 2
+      template_only: false
+      cases:
+        - query: "reaction"
+          mode: keyword
+          tags: ["work"]
+          expected:
+            - path: "private/./private-reaction.gif"
+    YAML
+    valid_file.flush
+
+    template_file = Tempfile.new([ "search-relevance-template", ".yml" ])
+    template_file.write(<<~YAML)
+      version: 2
+      template_only: true
+      cases: []
+    YAML
+    template_file.flush
+
+    cases = SearchRelevanceEvaluator.load_cases(valid_file.path)
+    assert_equal "reaction", cases.first.fetch("query")
+    evaluator = SearchRelevanceEvaluator.new(cases:, searcher: ->(*) { [] })
+    result = evaluator.call
+    assert_equal [ "path:private/private-reaction.gif" ], result.case_results.first.fetch("expected")
+    assert_raises(SearchRelevanceEvaluator::DatasetError) do
+      SearchRelevanceEvaluator.load_cases(template_file.path)
+    end
+    assert_raises(SearchRelevanceEvaluator::DatasetError) do
+      SearchRelevanceEvaluator.load_cases("#{valid_file.path}.missing")
+    end
+  ensure
+    valid_file&.close!
+    template_file&.close!
+  end
+
+  test "distinguishes duplicate filenames by normalized relative path" do
+    cases = [
+      {
+        "query" => "same name",
+        "expected" => [ { "path" => "wanted/duplicate.gif" } ]
+      }
+    ]
+    searcher = ->(*) {
+      [
+        TestResult.new(id: 10, relative_path: "wrong/duplicate.gif"),
+        TestResult.new(id: 11, relative_path: "wanted/./duplicate.gif")
+      ]
+    }
+
+    result = SearchRelevanceEvaluator.new(cases:, searcher:).call(k: 2)
+
+    assert_equal true, result.case_results.first["hit"]
+    assert_equal 0.5, result.case_results.first["reciprocal_rank"]
+    assert_equal 1.0, result.case_results.first["recall"]
+  end
+
+  test "rejects a result missing both a stable id and relative path" do
+    evaluator = SearchRelevanceEvaluator.new(
+      cases: [ { "query" => "missing identity", "expected" => [ { "id" => 1 } ] } ],
+      searcher: ->(*) { [ TestResult.new(id: nil, relative_path: nil) ] }
+    )
+
+    error = assert_raises(SearchRelevanceEvaluator::DatasetError) { evaluator.call }
+
+    assert_match "missing both", error.message
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.61.1",
+        "@redocly/cli": "^2.41.2",
         "@types/node": "^26.1.1",
         "axios": "^1.18.1",
         "dotenv": "^17.4.2",
@@ -30,6 +31,21 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "2.41.2",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.41.2.tgz",
+      "integrity": "sha512-xCRdFatUF3N6IjAgdWXakolqqfDqUPsXPXW5nS+3xrPd/BXS03olTvOG5DJNlnplusodS7zuu7sGExPJBv8TDw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:e2e:docker:ui": "playwright test --config=playwright-docker/config/playwright.config.docker.ts --ui",
     "test:e2e:docker:headed": "playwright test --config=playwright-docker/config/playwright.config.docker.ts --headed",
     "test:e2e:docker:debug": "playwright test --config=playwright-docker/config/playwright.config.docker.ts --debug",
-    "test:e2e:docker:report": "playwright show-report playwright-docker/playwright-report-docker"
+    "test:e2e:docker:report": "playwright show-report playwright-docker/playwright-report-docker",
+    "contract:openapi": "redocly lint docs/search-api-openapi.yml --extends=minimal"
   },
   "repository": {
     "type": "git",
@@ -39,6 +40,7 @@
   "homepage": "https://github.com/neonwatty/meme-search#readme",
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "@redocly/cli": "^2.41.2",
     "@types/node": "^26.1.1",
     "axios": "^1.18.1",
     "dotenv": "^17.4.2",

--- a/scripts/run_all_ci_tests.sh
+++ b/scripts/run_all_ci_tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Unified CI Test Runner
-# Mirrors GitHub Actions workflows for local testing
-# Run from project root: bash run_all_ci_tests.sh
+# Runs the required GitHub Actions suite families locally.
+# Run from the project root: bash scripts/run_all_ci_tests.sh
 
-set -e  # Exit on first error
+set -uo pipefail
 
 # Color codes for output
 RED='\033[0;31m'
@@ -18,6 +18,7 @@ FAILED_TESTS=()
 
 # Track processes for cleanup
 RAILS_SERVER_PID=""
+RUNNER_DB_CONTAINER=""
 
 # Helper function to print section headers
 print_header() {
@@ -31,6 +32,18 @@ print_header() {
 # Helper function to track failures
 track_failure() {
     FAILED_TESTS+=("$1")
+}
+
+run_tracked() {
+    local label="$1"
+    shift
+    print_header "$label"
+    if "$@"; then
+        echo -e "${GREEN}✓ ${label} passed${NC}"
+    else
+        echo -e "${RED}❌ ${label} failed${NC}"
+        track_failure "$label"
+    fi
 }
 
 # Function to check Docker daemon status
@@ -77,53 +90,74 @@ cleanup() {
         wait $RAILS_SERVER_PID 2>/dev/null || true
     fi
 
-    # Kill any stray Rails servers on port 3000
-    if lsof -ti:3000 >/dev/null 2>&1; then
-        echo "Stopping Rails servers on port 3000..."
-        lsof -ti:3000 | xargs kill -9 2>/dev/null || true
-    fi
-
-    # Optional: Stop Docker containers if CLEANUP_DOCKER is set
-    if [ "${CLEANUP_DOCKER:-false}" = "true" ]; then
-        echo "Stopping Docker containers..."
-        docker compose down 2>/dev/null || true
+    # Remove only the ephemeral database created by this runner. Never stop the
+    # application's Compose stack or a caller-managed database.
+    if [ -n "$RUNNER_DB_CONTAINER" ]; then
+        echo "Stopping runner-owned PostgreSQL container ($RUNNER_DB_CONTAINER)..."
+        docker rm -f "$RUNNER_DB_CONTAINER" >/dev/null 2>&1 || true
+        RUNNER_DB_CONTAINER=""
     fi
 
     echo -e "${GREEN}✓ Cleanup complete${NC}"
 }
 
-# Register cleanup trap (runs on exit, interrupt, or termination)
-trap cleanup EXIT INT TERM
+# Register cleanup on every exit. Signal handlers terminate with a useful code;
+# the EXIT handler then performs the same owned-resource cleanup.
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-# Check prerequisites
-print_header "Checking Prerequisites"
+setup_rails_database() {
+    if [ -n "${DATABASE_URL:-}" ]; then
+        echo -e "${GREEN}✓ Using caller-supplied DATABASE_URL${NC}"
+        return 0
+    fi
 
-# Check if mise is available
-if ! command -v mise &> /dev/null; then
-    echo -e "${RED}❌ mise not found. Please install mise first.${NC}"
-    exit 1
-fi
-echo -e "${GREEN}✓ mise found${NC}"
+    check_docker
 
-# Check Docker daemon before proceeding
-check_docker
+    RUNNER_DB_CONTAINER="meme-search-ci-db-$$-$(date +%s)"
+    echo -e "${YELLOW}⚠️  DATABASE_URL is unset; starting an ephemeral pgvector database...${NC}"
 
-# Check if PostgreSQL is running
-if ! docker ps | grep -q pgvector; then
-    echo -e "${YELLOW}⚠️  PostgreSQL with pgvector not running. Starting with docker compose...${NC}"
-    docker compose up -d
-    sleep 5
-fi
-echo -e "${GREEN}✓ PostgreSQL running${NC}"
+    if ! docker run -d --rm \
+        --name "$RUNNER_DB_CONTAINER" \
+        -e POSTGRES_USER=postgres \
+        -e POSTGRES_PASSWORD=postgres \
+        -e POSTGRES_DB=postgres \
+        -p 127.0.0.1::5432 \
+        pgvector/pgvector:pg17 >/dev/null; then
+        echo -e "${RED}❌ Failed to start the runner-owned PostgreSQL container${NC}"
+        return 1
+    fi
 
-# Check if in correct directory
-if [ ! -f "package.json" ] || [ ! -d "meme_search" ]; then
-    echo -e "${RED}❌ Must run from project root directory${NC}"
-    exit 1
-fi
-echo -e "${GREEN}✓ Running from project root${NC}"
+    local ready=false
+    for _ in {1..30}; do
+        if docker exec "$RUNNER_DB_CONTAINER" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
+            ready=true
+            break
+        fi
+        sleep 1
+    done
 
-# Parse command line arguments
+    if [ "$ready" != "true" ]; then
+        echo -e "${RED}❌ Runner-owned PostgreSQL did not become ready${NC}"
+        return 1
+    fi
+
+    local runner_db_port
+    runner_db_port="$(docker inspect \
+        --format '{{(index (index .NetworkSettings.Ports "5432/tcp") 0).HostPort}}' \
+        "$RUNNER_DB_CONTAINER")"
+    if ! [[ "$runner_db_port" =~ ^[0-9]+$ ]]; then
+        echo -e "${RED}❌ Could not resolve the runner-owned PostgreSQL port${NC}"
+        return 1
+    fi
+
+    export DATABASE_URL="postgres://postgres:postgres@127.0.0.1:${runner_db_port}/meme_test"
+    echo -e "${GREEN}✓ Runner-owned PostgreSQL ready on 127.0.0.1:${runner_db_port}${NC}"
+}
+
+# Parse options before prerequisite checks so focused non-Rails commands do not
+# require Docker or a database they never use.
 SKIP_E2E=false
 SKIP_RAILS=false
 SKIP_PYTHON=false
@@ -148,7 +182,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --help)
-            echo "Usage: bash run_all_ci_tests.sh [options]"
+            echo "Usage: bash scripts/run_all_ci_tests.sh [options]"
             echo ""
             echo "Options:"
             echo "  --skip-e2e      Skip Playwright E2E tests"
@@ -156,11 +190,6 @@ while [[ $# -gt 0 ]]; do
             echo "  --skip-python   Skip all Python tests"
             echo "  --verbose       Show detailed output"
             echo "  --help          Show this help message"
-            echo ""
-            echo "Examples:"
-            echo "  bash run_all_ci_tests.sh                    # Run all tests"
-            echo "  bash run_all_ci_tests.sh --skip-e2e         # Skip E2E tests (faster)"
-            echo "  bash run_all_ci_tests.sh --skip-rails       # Only run Python tests"
             exit 0
             ;;
         *)
@@ -170,6 +199,29 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Check prerequisites
+print_header "Checking Prerequisites"
+
+# Check if mise is available
+if ! command -v mise &> /dev/null; then
+    echo -e "${RED}❌ mise not found. Please install mise first.${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✓ mise found${NC}"
+
+if [ "$SKIP_RAILS" = false ]; then
+    if ! setup_rails_database; then
+        exit 1
+    fi
+fi
+
+# Check if in correct directory
+if [ ! -f "package.json" ] || [ ! -d "meme_search" ]; then
+    echo -e "${RED}❌ Must run from project root directory${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✓ Running from project root${NC}"
 
 # =============================================================================
 # RAILS APP TESTS
@@ -212,7 +264,21 @@ if [ "$SKIP_RAILS" = false ]; then
         echo -e "${GREEN}✓ Test database prepared${NC}"
     else
         echo -e "${RED}❌ Failed to prepare test database${NC}"
+        if [ -n "${DATABASE_URL:-}" ]; then
+            echo "Check that DATABASE_URL points to a reachable PostgreSQL server with pgvector support."
+        fi
         track_failure "Rails: DB Prepare"
+        cd ../..
+        exit 1
+    fi
+
+    # Match the workflow's fresh-checkout setup before view-rendering suites.
+    print_header "Rails: Precompiling Test Assets"
+    if mise exec -- bundle exec rake assets:precompile; then
+        echo -e "${GREEN}✓ Test assets precompiled${NC}"
+    else
+        echo -e "${RED}❌ Failed to precompile test assets${NC}"
+        track_failure "Rails: Asset Precompile"
         cd ../..
         exit 1
     fi
@@ -230,7 +296,7 @@ if [ "$SKIP_RAILS" = false ]; then
         [ "$VERBOSE" = false ] && tail -5 /tmp/rails_model_tests.log
     else
         echo -e "${RED}❌ Model tests failed${NC}"
-        cat /tmp/rails_model_tests.log
+        [ -f /tmp/rails_model_tests.log ] && cat /tmp/rails_model_tests.log
         track_failure "Rails: Model Tests"
     fi
 
@@ -247,7 +313,7 @@ if [ "$SKIP_RAILS" = false ]; then
         [ "$VERBOSE" = false ] && tail -5 /tmp/rails_controller_tests.log
     else
         echo -e "${RED}❌ Controller tests failed${NC}"
-        cat /tmp/rails_controller_tests.log
+        [ -f /tmp/rails_controller_tests.log ] && cat /tmp/rails_controller_tests.log
         track_failure "Rails: Controller Tests"
     fi
 
@@ -264,9 +330,15 @@ if [ "$SKIP_RAILS" = false ]; then
         [ "$VERBOSE" = false ] && tail -5 /tmp/rails_channel_tests.log
     else
         echo -e "${RED}❌ Channel tests failed${NC}"
-        cat /tmp/rails_channel_tests.log
+        [ -f /tmp/rails_channel_tests.log ] && cat /tmp/rails_channel_tests.log
         track_failure "Rails: Channel Tests"
     fi
+
+    # Required Rails suites that have dedicated CI steps.
+    run_tracked "Rails: Service Tests" mise exec -- bin/rails test test/services
+    run_tracked "Rails: API Contract Tests" mise exec -- bin/rails test test/contracts
+    run_tracked "Rails: Database and Migration Tests" mise exec -- bin/rails test test/db
+    run_tracked "Rails: Rake Task Tests" mise exec -- bin/rails test test/tasks
 
     cd ../..
 fi
@@ -300,7 +372,7 @@ if [ "$SKIP_PYTHON" = false ]; then
         [ "$VERBOSE" = false ] && tail -10 /tmp/python_integration_tests.log
     else
         echo -e "${RED}❌ Integration tests failed${NC}"
-        cat /tmp/python_integration_tests.log
+        [ -f /tmp/python_integration_tests.log ] && cat /tmp/python_integration_tests.log
         track_failure "Python: Integration Tests"
     fi
 
@@ -317,11 +389,29 @@ if [ "$SKIP_PYTHON" = false ]; then
         [ "$VERBOSE" = false ] && tail -15 /tmp/python_unit_tests.log
     else
         echo -e "${RED}❌ Unit tests with coverage failed${NC}"
-        cat /tmp/python_unit_tests.log
+        [ -f /tmp/python_unit_tests.log ] && cat /tmp/python_unit_tests.log
         track_failure "Python: Unit Tests"
     fi
 
     cd ../..
+fi
+
+# =============================================================================
+# ROOT CONTRACT AND LOCAL INTEGRATION CLIENTS
+# =============================================================================
+
+# The focused test:rails and test:python aliases intentionally remain focused.
+# The default/test:ci entrypoint runs the complete cross-project CI surface.
+if [ "$SKIP_RAILS" = false ] && [ "$SKIP_PYTHON" = false ]; then
+    run_tracked "Repository: OpenAPI 3.1 Contract" npm run contract:openapi
+    run_tracked "Repository: Node Dependency Audit" npm audit --audit-level=high
+    run_tracked "Repository: TypeScript Check" npx tsc --noEmit
+    run_tracked "Repository: Discord Link Check" bash scripts/validate_discord_link.sh
+
+    run_tracked "Local CLI: Tests" \
+        bash -c "cd integrations/cli && python3 -m unittest discover -v && python3 -m py_compile meme_search_cli.py meme-search"
+    run_tracked "Browser Extension: Tests and Static Checks" \
+        bash -c "cd integrations/browser-extension && npm test && npm run check && node -e 'JSON.parse(require(\"fs\").readFileSync(\"manifest.json\", \"utf8\"))' && ! rg 'innerHTML|outerHTML|insertAdjacentHTML' . --glob '*.js' && ! rg --pcre2 'https?://(?!127\\.0\\.0\\.1|localhost)' . --glob '*.js' --glob '!test/**'"
 fi
 
 # =============================================================================
@@ -371,7 +461,7 @@ if [ "$SKIP_E2E" = false ] && [ "$SKIP_RAILS" = false ]; then
         [ "$VERBOSE" = false ] && tail -10 /tmp/playwright_tests.log
     else
         echo -e "${RED}❌ Playwright E2E tests failed${NC}"
-        cat /tmp/playwright_tests.log
+        [ -f /tmp/playwright_tests.log ] && cat /tmp/playwright_tests.log
         track_failure "Playwright: E2E Tests"
     fi
 

--- a/scripts/test_run_all_ci_tests_db.sh
+++ b/scripts/test_run_all_ci_tests_db.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="$PROJECT_ROOT/scripts/run_all_ci_tests.sh"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    rg -F -- "$expected" "$file" >/dev/null || fail "$file does not contain: $expected"
+}
+
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    if rg -F -- "$unexpected" "$file" >/dev/null 2>&1; then
+        fail "$file unexpectedly contains: $unexpected"
+    fi
+}
+
+make_stubs() {
+    local case_dir="$1"
+    mkdir -p "$case_dir/bin"
+
+    cat > "$case_dir/bin/docker" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+echo "$*|${DATABASE_URL:-unset}" >> "$STUB_LOG"
+case "${1:-}" in
+    ps) exit 0 ;;
+    run)
+        printf '%s\n' "fake-container-id"
+        exit 0
+        ;;
+    exec) exit 0 ;;
+    inspect)
+        printf '%s\n' "49152"
+        exit 0
+        ;;
+    rm) exit 0 ;;
+esac
+exit 0
+EOF
+
+    cat > "$case_dir/bin/mise" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+echo "$*|${DATABASE_URL:-unset}" >> "$STUB_LOG"
+if [[ "$*" == *"bin/rails db:test:prepare"* ]] && [ "${STUB_DB_PREPARE_FAIL:-false}" = "true" ]; then
+    exit 1
+fi
+if [[ "$*" == *"bin/rails db:test:prepare"* ]] && [ "${STUB_SIGNAL_PARENT:-false}" = "true" ]; then
+    touch "$STUB_BLOCK_MARKER"
+    kill -TERM "$PPID"
+    sleep 1
+fi
+exit 0
+EOF
+
+    chmod +x "$case_dir/bin/docker" "$case_dir/bin/mise"
+}
+
+run_case() {
+    local name="$1"
+    shift
+    local case_dir="$TEST_ROOT/$name"
+    mkdir -p "$case_dir"
+    make_stubs "$case_dir"
+    : > "$case_dir/log"
+    (
+        cd "$PROJECT_ROOT"
+        env PATH="$case_dir/bin:/usr/bin:/bin" \
+            STUB_LOG="$case_dir/log" \
+            "$@" \
+            bash "$RUNNER" --skip-python --skip-e2e >/dev/null 2>&1
+    )
+}
+
+unset_case="$TEST_ROOT/unset"
+run_case unset env -u DATABASE_URL
+assert_contains "$unset_case/log" "run -d --rm --name meme-search-ci-db-"
+assert_contains "$unset_case/log" "-p 127.0.0.1::5432"
+assert_contains "$unset_case/log" "bin/rails db:test:prepare|postgres://postgres:postgres@127.0.0.1:49152/meme_test"
+assert_contains "$unset_case/log" "bundle exec rake assets:precompile|postgres://postgres:postgres@127.0.0.1:49152/meme_test"
+assert_contains "$unset_case/log" "rm -f meme-search-ci-db-"
+assert_not_contains "$unset_case/log" "docker compose"
+
+provided_case="$TEST_ROOT/provided"
+run_case provided env DATABASE_URL="postgres://caller.example/test"
+assert_contains "$provided_case/log" "bin/rails db:test:prepare|postgres://caller.example/test"
+assert_contains "$provided_case/log" "bundle exec rake assets:precompile|postgres://caller.example/test"
+assert_not_contains "$provided_case/log" "run -d --rm"
+assert_not_contains "$provided_case/log" "rm -f meme-search-ci-db-"
+
+invalid_case="$TEST_ROOT/invalid"
+mkdir -p "$invalid_case"
+make_stubs "$invalid_case"
+: > "$invalid_case/log"
+if (
+    cd "$PROJECT_ROOT"
+    env PATH="$invalid_case/bin:/usr/bin:/bin" \
+        STUB_LOG="$invalid_case/log" \
+        STUB_DB_PREPARE_FAIL=true \
+        DATABASE_URL="postgres://invalid.example/test" \
+        bash "$RUNNER" --skip-python --skip-e2e >/dev/null 2>&1
+); then
+    fail "invalid DATABASE_URL unexpectedly succeeded"
+fi
+assert_not_contains "$invalid_case/log" "run -d --rm"
+
+interrupt_case="$TEST_ROOT/interrupt"
+mkdir -p "$interrupt_case"
+make_stubs "$interrupt_case"
+: > "$interrupt_case/log"
+block_marker="$interrupt_case/blocked"
+if (
+    cd "$PROJECT_ROOT"
+    env -u DATABASE_URL \
+        PATH="$interrupt_case/bin:/usr/bin:/bin" \
+        STUB_LOG="$interrupt_case/log" \
+        STUB_SIGNAL_PARENT=true \
+        STUB_BLOCK_MARKER="$block_marker" \
+        bash "$RUNNER" --skip-python --skip-e2e >/dev/null 2>&1
+) ; then
+    fail "interrupt case unexpectedly succeeded"
+fi
+[ -f "$block_marker" ] || fail "interrupt case never reached database preparation"
+assert_contains "$interrupt_case/log" "rm -f meme-search-ci-db-"
+
+echo "Local CI database wiring tests passed"


### PR DESCRIPTION
## Summary

- add a dependency-free Python CLI for token-authenticated local search and explicit media fetches
- add shared response-conformance coverage for the CLI and Chromium extension
- add an optional, UI-independent relevance evaluator with a privacy-safe replace-me dataset
- validate the OpenAPI 3.1 document and integration clients in hosted CI
- make the local CI runner use an isolated loopback-only pgvector container when `DATABASE_URL` is unset, precompile Rails assets, and clean up only resources it owns
- document setup, security boundaries, client behavior, relevance metrics, and local CI parity

## Security boundaries

- remains officially loopback-only
- bearer credentials are never sent across redirects
- plain HTTP is rejected for non-loopback instances
- media fetches accept only API content paths and refuse symlink/concurrent no-force clobbers
- relevance fixtures must not contain private collection data
- no client is published to a package or extension store

## Verification

- CLI: 24 tests plus bytecode compilation
- relevance evaluator: 7 tests / 34 assertions; RuboCop clean
- OpenAPI 3.1 validation and root dependency audit: clean
- shared extension conformance regression: 23 tests, checks, and dependency audit clean
- Search API contract/controllers: 29 tests / 347 assertions
- local CI database ownership/cleanup tests: pass
- exact branch diff check and secret/path scan: clean

The required GitHub matrix is the merge gate. A local full-run audit additionally exposed two pre-existing host/baseline conditions: macOS lacks `libvips`, which GitHub CI installs, and the legacy `test/integration` rescan suite has five failures on untouched `main`, so that non-required suite is not newly promoted to a merge gate in this PR.