### PR TITLE
Retry transient Docker database preparation

### DIFF
--- a/.github/workflows/pro-app-test.yml
+++ b/.github/workflows/pro-app-test.yml
@@ -21,6 +21,7 @@ on:
       - "docker-compose.yml"
       - "docker-compose-local-build.yml"
       - "scripts/validate_discord_link.sh"
+      - "scripts/test_docker_entrypoint.sh"
       - "scripts/run_all_ci_tests.sh"
       - "!meme_search/meme_search_app/**/*.md"
       - "!meme_search/meme_search_app/**/LICENSE"
@@ -43,6 +44,7 @@ on:
       - "docker-compose.yml"
       - "docker-compose-local-build.yml"
       - "scripts/validate_discord_link.sh"
+      - "scripts/test_docker_entrypoint.sh"
       - "scripts/run_all_ci_tests.sh"
       - "!meme_search/meme_search_app/**/*.md"
       - "!meme_search/meme_search_app/**/LICENSE"
@@ -51,6 +53,16 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  docker_entrypoint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Test bounded database preparation retries
+        run: bash scripts/test_docker_entrypoint.sh
+
   validate_discord_link:
     runs-on: ubuntu-latest
 

--- a/meme_search/meme_search_app/bin/docker-entrypoint
+++ b/meme_search/meme_search_app/bin/docker-entrypoint
@@ -6,9 +6,30 @@ if [ -z "${LD_PRELOAD+x}" ] && [ -f /usr/lib/*/libjemalloc.so.2 ]; then
 fi
 
 # If running the Rails server or job worker then create or migrate the database.
+prepare_database() {
+  local max_attempts=5
+  local retry_delay_seconds=2
+  local attempt=1
+
+  while [ "${attempt}" -le "${max_attempts}" ]; do
+    if ./bin/rails db:prepare; then
+      return 0
+    fi
+
+    if [ "${attempt}" -eq "${max_attempts}" ]; then
+      echo "Database preparation failed after ${max_attempts} attempts." >&2
+      return 1
+    fi
+
+    echo "Database preparation failed (attempt ${attempt}/${max_attempts}); retrying in ${retry_delay_seconds}s." >&2
+    sleep "${retry_delay_seconds}"
+    attempt=$((attempt + 1))
+  done
+}
+
 if { [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; } || [ "${1}" == "./bin/jobs" ]; then
   # Prepare the database (create, migrate, seed, etc.)
-  ./bin/rails db:prepare
+  prepare_database
 fi
 
 exec "${@}"

--- a/scripts/run_all_ci_tests.sh
+++ b/scripts/run_all_ci_tests.sh
@@ -223,6 +223,8 @@ if [ ! -f "package.json" ] || [ ! -d "meme_search" ]; then
 fi
 echo -e "${GREEN}✓ Running from project root${NC}"
 
+run_tracked "Docker entrypoint retry tests" bash scripts/test_docker_entrypoint.sh
+
 # =============================================================================
 # RAILS APP TESTS
 # =============================================================================

--- a/scripts/test_docker_entrypoint.sh
+++ b/scripts/test_docker_entrypoint.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ENTRYPOINT_TEST_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENTRYPOINT_UNDER_TEST="${ENTRYPOINT_TEST_REPO_ROOT}/meme_search/meme_search_app/bin/docker-entrypoint"
+ENTRYPOINT_TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meme-search-entrypoint-test.XXXXXX")"
+
+cleanup_entrypoint_tests() {
+  rm -rf -- "${ENTRYPOINT_TEST_ROOT}"
+}
+trap cleanup_entrypoint_tests EXIT
+
+fail_entrypoint_test() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_log_count() {
+  local expected_count="$1"
+  local expected_line="$2"
+  local log_path="$3"
+  local actual_count
+
+  actual_count="$(grep -Fxc "${expected_line}" "${log_path}" 2>/dev/null || true)"
+  if [ "${actual_count}" != "${expected_count}" ]; then
+    fail_entrypoint_test "expected ${expected_count} occurrence(s) of '${expected_line}', got ${actual_count}"
+  fi
+}
+
+setup_entrypoint_fixture() {
+  local fixture_name="$1"
+  local fixture_path="${ENTRYPOINT_TEST_ROOT}/${fixture_name}"
+
+  mkdir -p "${fixture_path}/bin" "${fixture_path}/fake-bin"
+
+  cat > "${fixture_path}/bin/rails" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'rails:%s\n' "$*" >> "${ENTRYPOINT_TEST_LOG}"
+
+if [ "${1:-}" = "db:prepare" ]; then
+  prepare_count=0
+  if [ -f "${ENTRYPOINT_TEST_COUNT_FILE}" ]; then
+    read -r prepare_count < "${ENTRYPOINT_TEST_COUNT_FILE}"
+  fi
+  prepare_count=$((prepare_count + 1))
+  printf '%s\n' "${prepare_count}" > "${ENTRYPOINT_TEST_COUNT_FILE}"
+
+  if [ "${prepare_count}" -le "${ENTRYPOINT_TEST_PREPARE_FAILURES:-0}" ]; then
+    echo "simulated db:prepare failure ${prepare_count}" >&2
+    exit 42
+  fi
+fi
+STUB
+
+  cat > "${fixture_path}/bin/jobs" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'jobs:%s\n' "$*" >> "${ENTRYPOINT_TEST_LOG}"
+STUB
+
+  cat > "${fixture_path}/fake-bin/sleep" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'sleep:%s\n' "$*" >> "${ENTRYPOINT_TEST_LOG}"
+STUB
+
+  chmod +x "${fixture_path}/bin/rails" "${fixture_path}/bin/jobs" "${fixture_path}/fake-bin/sleep"
+  printf '%s\n' "${fixture_path}"
+}
+
+run_entrypoint_fixture() {
+  local fixture_path="$1"
+  local prepare_failures="$2"
+  shift 2
+
+  (
+    cd "${fixture_path}"
+    ENTRYPOINT_TEST_LOG="${fixture_path}/calls.log" \
+      ENTRYPOINT_TEST_COUNT_FILE="${fixture_path}/prepare-count" \
+      ENTRYPOINT_TEST_PREPARE_FAILURES="${prepare_failures}" \
+      PATH="${fixture_path}/fake-bin:${PATH}" \
+      "${ENTRYPOINT_UNDER_TEST}" "$@"
+  )
+}
+
+transient_fixture="$(setup_entrypoint_fixture transient)"
+run_entrypoint_fixture "${transient_fixture}" 1 ./bin/rails server -b 0.0.0.0
+assert_log_count 2 "rails:db:prepare" "${transient_fixture}/calls.log"
+assert_log_count 1 "sleep:2" "${transient_fixture}/calls.log"
+assert_log_count 1 "rails:server -b 0.0.0.0" "${transient_fixture}/calls.log"
+
+jobs_fixture="$(setup_entrypoint_fixture jobs)"
+run_entrypoint_fixture "${jobs_fixture}" 1 ./bin/jobs
+assert_log_count 2 "rails:db:prepare" "${jobs_fixture}/calls.log"
+assert_log_count 1 "sleep:2" "${jobs_fixture}/calls.log"
+assert_log_count 1 "jobs:" "${jobs_fixture}/calls.log"
+
+persistent_fixture="$(setup_entrypoint_fixture persistent)"
+if run_entrypoint_fixture "${persistent_fixture}" 99 ./bin/rails server >"${persistent_fixture}/stdout.log" 2>"${persistent_fixture}/stderr.log"; then
+  fail_entrypoint_test "persistent db:prepare failure unexpectedly started the server"
+fi
+assert_log_count 5 "rails:db:prepare" "${persistent_fixture}/calls.log"
+assert_log_count 4 "sleep:2" "${persistent_fixture}/calls.log"
+assert_log_count 0 "rails:server" "${persistent_fixture}/calls.log"
+grep -Fq "Database preparation failed after 5 attempts." "${persistent_fixture}/stderr.log" ||
+  fail_entrypoint_test "persistent failure did not report retry exhaustion"
+
+bypass_fixture="$(setup_entrypoint_fixture bypass)"
+run_entrypoint_fixture "${bypass_fixture}" 99 ./bin/rails db:migrate:status
+assert_log_count 1 "rails:db:migrate:status" "${bypass_fixture}/calls.log"
+assert_log_count 0 "rails:db:prepare" "${bypass_fixture}/calls.log"
+assert_log_count 0 "sleep:2" "${bypass_fixture}/calls.log"
+
+echo "Docker entrypoint retry tests passed."


### PR DESCRIPTION
## What changed

- retry `db:prepare` up to five times for the web and jobs entrypoints
- stop with a nonzero exit after persistent preparation failures
- add deterministic shell coverage for transient web/jobs failures, retry exhaustion, and non-server bypass behavior
- run the focused test in CI and the unified local test runner

## Why

Fresh simultaneous Docker Compose startup can race while both application processes enable pgvector. A transient `PG::UniqueViolation` can otherwise stop one process even though the database finishes preparing successfully. Closes #200.

## Impact

Fresh installs can recover from this bounded startup race. Persistent migration or database failures remain visible and prevent the application process from starting.

## Checks

- `bash scripts/test_docker_entrypoint.sh`
- `bash -n meme_search/meme_search_app/bin/docker-entrypoint scripts/test_docker_entrypoint.sh scripts/run_all_ci_tests.sh`
- workflow YAML parse
- `git diff --check`

This PR intentionally does not change the database schema, API contract, documentation, `VERSION`, tags, or releases.