### PR TITLE
Point Search API demo links to the web player

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Visit the [Meme Search project site](https://neonwatty.github.io/meme-search/) f
 > The API is read-only and officially supported on loopback; it also gives
 > community integrations a stable boundary that does not expose your database.
 
+[Watch the 16-second app-and-CLI demo](https://neonwatty.github.io/meme-search/#integrations).
+
   <p align="center">
     <img src="https://github.com/user-attachments/assets/0529764f-a009-4e17-8947-63c7c96075a5"
   alt="meme-search-2.0-demo">

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -16,7 +16,7 @@ Do not expose the app directly to a public network.
 - [Search API guide and OpenAPI contract](https://github.com/neonwatty/meme-search/blob/v2.3.0/docs/search-api.md)
 - [Dependency-free Python CLI](https://github.com/neonwatty/meme-search/tree/v2.3.0/integrations/cli)
 - [Experimental unpacked Chromium popup](https://github.com/neonwatty/meme-search/tree/v2.3.0/integrations/browser-extension)
-- [16-second app-and-CLI demo](https://github.com/neonwatty/meme-search/blob/v2.3.0/docs/assets/search-api/search-api-v1-demo-short.mp4)
+- [16-second app-and-CLI demo](https://neonwatty.github.io/meme-search/#integrations)
 - [Propose a community integration](https://github.com/neonwatty/meme-search/issues/197)
 
 ## What is included

--- a/docs/search-api.md
+++ b/docs/search-api.md
@@ -20,7 +20,7 @@ exposure supported.
 
 ## See it in action
 
-[Watch the 16-second silent app-and-CLI demo](assets/search-api/search-api-v1-demo-short.mp4),
+[Watch the 16-second silent app-and-CLI demo](https://neonwatty.github.io/meme-search/#integrations),
 or read its [timed transcript and exact commands](demos/search-api-v1-demo.md).
 
 | Web app | Local CLI |


### PR DESCRIPTION
## What changed

- add a prominent 16-second Search API demo link near the README launch callout
- point the Search API guide at the browser-playable project-site player
- point the checked-in v2.3.0 release notes at the same canonical player

## Why

The previous GitHub blob links were download-oriented and did not reliably play inline. The project site now provides a native video player, so repository messaging should direct users there consistently.

## User impact

Users can watch the app-and-CLI demo directly in the browser from the README, API guide, or release notes.

## Validation

- `git diff --check`
- `npm run test:site`
- live HTTP 200 check for `https://neonwatty.github.io/meme-search/#integrations`
- verified the deployed page contains `id="integrations"` and the MP4 source